### PR TITLE
add apply_filters to allow developers to control horizon.js and spm appearance

### DIFF
--- a/classes/class-sailthru-horizon.php
+++ b/classes/class-sailthru-horizon.php
@@ -342,7 +342,7 @@ class Sailthru_Horizon {
         $js .= "});\n";
  		$js .= "</script>\n";
 
-		if ( !is_404() &&  !is_preview() ) {
+		if ( !is_404() && !is_preview() && apply_filters( 'sailthru_add_spm_js', true ) ) {
 			echo $js;
 		}
 
@@ -444,7 +444,7 @@ class Sailthru_Horizon {
 			$horizon_js .= " </script>\n";
 		}
 
-		if ( !is_404() &&  !is_preview() ) {
+		if ( !is_404() &&  !is_preview() && apply_filters( 'sailthru_add_horizon_js', true ) ) {
 			echo $horizon_js;
 		}
 


### PR DESCRIPTION
It would be great to have an ability to control the enabling or disabling the horizon.js per pages programmatically. 
