### PR TITLE
Change escaping in Sailthru widget title from esc_html() to wp_kses_p…

### DIFF
--- a/views/widget.subscribe.display.php
+++ b/views/widget.subscribe.display.php
@@ -37,7 +37,7 @@
                         $after_title = '';
                     }
 
-                    echo $before_title . esc_html( trim( $title ) ) . $after_title;
+                    echo $before_title . wp_kses_post( trim( $title ) ) . $after_title;
                 }
 
                 // success message


### PR DESCRIPTION
…ost()

The Sailthru widget correctly applies the `widget_title` filter, but then incorrectly uses `esc_html()` to escape the output.

Both core and Jetpack don't escape the output of the widget title at all. In the interim, `wp_kses_post()` will permit some additional HTML to be included via the filter.