### PR TITLE
Change scope of error message to current form. 

### DIFF
--- a/js/widget.subscribe.js
+++ b/js/widget.subscribe.js
@@ -31,7 +31,7 @@
 				function(data) {
 					data = jQuery.parseJSON(data);
 					if( data.success == false ) {
-						$(".sailthru-add-subscriber-errors").html(data.message);
+						$('#'+ form.attr('id') + " .sailthru-add-subscriber-errors").html(data.message);
 					} else {
 						$('#sailthru-modal .sailthru-signup-widget-close').fadeIn();
 						$(form).html('');

--- a/views/widget.subscribe.display.php
+++ b/views/widget.subscribe.display.php
@@ -56,7 +56,7 @@ if ( ! empty( $instance['sailthru_list'] ) ) {
 
 			<div class="success" hidden="hidden"><?php echo esc_html( $success ); ?></div>
 
-			<form method="post" action="#" class="sailthru-add-subscriber-form">
+			<form method="post" action="#" class="sailthru-add-subscriber-form" id="<?php echo esc_attr( $widget_id ) ?>">
 
 				<div class="sailthru-add-subscriber-errors"></div>
 


### PR DESCRIPTION
Fixes #IN-955 to change the scope of how the error message displays to target the current form. This resolves an issue where two+ instances of a widget will display the error message when a single form is invalid. 