### PR TITLE
3.3.0

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,9 +1,9 @@
 === Sailthru for WordPress ===
-Contributors: nickgundry, sailthru-wp, automattic, irms, zackify, natebot
+Contributors: asilverman, nickgundry, sailthru-wp, automattic, irms, zackify, natebot
 Tags: personalization, email,
 Requires at least: 3.6
 Tested up to: 4.9.5
-Stable tag: 3.3-beta
+Stable tag: 3.3.0
 
 This plugin  provides fast and easy integration of the core Sailthru features into your Wordpress site.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,6 @@
 # Changelog
+## v3.3.0 (2018-11-12)
+Address codestyle issues for VIP
 
 ## v3.3-beta (2018-06-18)
 Added content settings section to the setup and migrated some horizon code to a common content class. 

--- a/classes/class-sailthru-content.php
+++ b/classes/class-sailthru-content.php
@@ -167,7 +167,7 @@ class Sailthru_Content_Settings {
 
         	$selected_types = isset($options['sailthru_content_post_types']) ? $options['sailthru_content_post_types'] : [];
         	foreach ( $post_types as $type ) {
-        		$selected = in_array( $type , $type_opts, true ) ? 'checked="checked"' : '';
+        		$selected = in_array( $type , $selected_types, true ) ? 'checked="checked"' : '';
         		echo '<input type="checkbox" name="sailthru_content_settings[sailthru_content_post_types][]" class="sailthru_content_post_types_field" value="' . esc_attr( $type ) . '" ' . $selected . '> ' . esc_attr__( ucwords ( $type ) , 'text_domain' ) . '<br>';
         	}
 
@@ -550,7 +550,7 @@ class Sailthru_Content_Settings {
 		}
 
 
-		if (in_array ( $post->post_type, $options['sailthru_content_post_types'] ) ) {
+		if ( in_array( $post->post_type, $options['sailthru_content_post_types'], true ) ) {
 
 			if ( 'publish' === $post->post_status ) {
 				// Make sure Sailthru is setup

--- a/classes/class-sailthru-content.php
+++ b/classes/class-sailthru-content.php
@@ -139,10 +139,10 @@ class Sailthru_Content_Settings {
 
 		// Field output.
 		echo '<select name="sailthru_content_settings[sailthru_content_api_status]" class="sailthru_content_api_status_field">';
-		echo '	<option value="true" ' . selected( $value, 'true', false ) . '> ' . __( 'Enabled', 'text_domain' ) . '</option>';
-		echo '	<option value="false" ' . selected( $value, 'false', false ) . '> ' . __( 'Disabled', 'text_domain' ) . '</option>';
+		echo '	<option value="true" ' . selected( $value, 'true', false ) . '> ' . esc_attr__( 'Enabled', 'text_domain' ) . '</option>';
+		echo '	<option value="false" ' . selected( $value, 'false', false ) . '> ' . esc_attr__( 'Disabled', 'text_domain' ) . '</option>';
 		echo '</select>';
-		echo '<p class="description">' . __( 'When Content API syncing is disabled Sailthru will crawl your web site to retrieve content for the Content Library.', 'text_domain' ) . '</p>';
+		echo '<p class="description">' . esc_attr__( 'When Content API syncing is disabled Sailthru will crawl your web site to retrieve content for the Content Library.', 'text_domain' ) . '</p>';
 
 	}
 
@@ -163,10 +163,12 @@ class Sailthru_Content_Settings {
         	// Always remove the attachment post type, we never need this. 
         	unset ($post_types['attachment']);
 
-        	echo '<p class="description">' . __( 'Choose which type of post types should be synced to Sailthru', 'text_domain' ) . '</p>';
+        	echo '<p class="description">' . esc_attr__( 'Choose which type of post types should be synced to Sailthru', 'text_domain' ) . '</p>';
 
+        	$selected_types = isset($options['sailthru_content_post_types']) ? $options['sailthru_content_post_types'] : [];
         	foreach ( $post_types as $type ) {
-        		echo '<input type="checkbox" name="sailthru_content_settings[sailthru_content_post_types][]" class="sailthru_content_post_types_field" value="' . esc_attr( $type ) . '" ' . ( in_array( $type , isset( $options['sailthru_content_post_types'] ) ? $options['sailthru_content_post_types'] : [] )? 'checked="checked"' : '' ) . '> ' . __( ucwords ( $type ) , 'text_domain' ) . '<br>';
+        		$selected = in_array( $type , $type_opts, true ) ? 'checked="checked"' : '';
+        		echo '<input type="checkbox" name="sailthru_content_settings[sailthru_content_post_types][]" class="sailthru_content_post_types_field" value="' . esc_attr( $type ) . '" ' . $selected . '> ' . esc_attr__( ucwords ( $type ) , 'text_domain' ) . '<br>';
         	}
 
 		}        
@@ -199,11 +201,11 @@ class Sailthru_Content_Settings {
 		$options = get_option( 'sailthru_content_settings' );
 
 		// Set default value.
-        $value = isset( $options['sailthru_interest_tag_options'] ) ? $options['sailthru_interest_tag_options'] : array();
+        $value = isset( $options['sailthru_interest_tag_options'] ) ? $options['sailthru_interest_tag_options'] : [];
 
 		// Field output.
-		echo '<input type="checkbox" name="sailthru_content_settings[sailthru_interest_tag_options][]" class="sailthru_interest_tag_options_field" value="' . esc_attr( 'wordpress_tags' ) . '" ' . ( in_array( 'wordpress_tags', $value )? 'checked="checked"' : '' ) . '> ' . __( 'WordPress Tags', 'text_domain' ) . '<br>';
-		echo '<input type="checkbox" name="sailthru_content_settings[sailthru_interest_tag_options][]" class="sailthru_interest_tag_options_field" value="' . esc_attr( 'wordpress_categories' ) . '" ' . ( in_array( 'wordpress_categories', $value )? 'checked="checked"' : '' ) . '> ' . __( 'WordPress Categories', 'text_domain' ) . '<br>';
+		echo '<input type="checkbox" name="sailthru_content_settings[sailthru_interest_tag_options][]" class="sailthru_interest_tag_options_field" value="' . esc_attr( 'wordpress_tags' ) . '" ' . ( in_array( 'wordpress_tags', $value, true )? 'checked="checked"' : '' ) . '> ' . esc_attr__( 'WordPress Tags', 'text_domain' ) . '<br>';
+		echo '<input type="checkbox" name="sailthru_content_settings[sailthru_interest_tag_options][]" class="sailthru_interest_tag_options_field" value="' . esc_attr( 'wordpress_categories' ) . '" ' . ( in_array( 'wordpress_categories', $value, true )? 'checked="checked"' : '' ) . '> ' . esc_attr__( 'WordPress Categories', 'text_domain' ) . '<br>';
 
 	}
 
@@ -224,7 +226,7 @@ class Sailthru_Content_Settings {
 
 		foreach ($taxonomies as $tag) {
 			
-			echo '<input type="checkbox" name="sailthru_content_settings[sailthru_taxonomy_tag_options][]" class="sailthru_taxonomy_tag_options_field" value="' . esc_attr( $tag ) . '" ' . ( in_array( $tag, $value )? 'checked="checked"' : '' ) . '" /> ' . __( $tag, 'text_domain' ) . '<br>';
+			echo '<input type="checkbox" name="sailthru_content_settings[sailthru_taxonomy_tag_options][]" class="sailthru_taxonomy_tag_options_field" value="' . esc_attr( $tag ) . '" ' . ( in_array( $tag, $value, true ) ? 'checked="checked"' : '' ) . '" /> ' . esc_attr__( $tag, 'text_domain' ) . '<br>';
 		}
 		
 	}

--- a/classes/class-sailthru-meta-box.php
+++ b/classes/class-sailthru-meta-box.php
@@ -45,7 +45,7 @@ class Sailthru_Meta_Box {
 		if ( isset( $options['sailthru_content_post_types'] )  && !empty( $options['sailthru_content_post_types'] ) ) {
 			
 			if ( ! in_array($post->post_type, $options['sailthru_content_post_types'] ) ) {
-				echo '<p>This content type is not enabled for Sailthru recommendations.</p><p><a href=" ' . admin_url( esc_url( 'admin.php?page=sailthru_content_settings') ) .' ">Enable this content type</a>.</p>';
+				echo '<p>This content type is not enabled for Sailthru recommendations.</p><p><a href=" ' . esc_url( admin_url( 'admin.php?page=sailthru_content_settings') ) .' ">Enable this content type</a>.</p>';
 				return;
 			}
 		}

--- a/classes/class-sailthru-meta-box.php
+++ b/classes/class-sailthru-meta-box.php
@@ -45,7 +45,7 @@ class Sailthru_Meta_Box {
 		if ( isset( $options['sailthru_content_post_types'] )  && !empty( $options['sailthru_content_post_types'] ) ) {
 			
 			if ( ! in_array($post->post_type, $options['sailthru_content_post_types'] ) ) {
-				echo '<p>This content type is not enabled for Sailthru recommendations.</p><p><a href=" ' . admin_url('admin.php?page=sailthru_content_settings') .' ">Enable this content type</a>.</p>';
+				echo '<p>This content type is not enabled for Sailthru recommendations.</p><p><a href=" ' . admin_url( esc_url( 'admin.php?page=sailthru_content_settings') ) .' ">Enable this content type</a>.</p>';
 				return;
 			}
 		}

--- a/classes/class-sailthru-meta-box.php
+++ b/classes/class-sailthru-meta-box.php
@@ -37,8 +37,8 @@ class Sailthru_Meta_Box {
 		$options = get_option( 'sailthru_content_settings' );
 
 		if ( isset( $options['sailthru_interest_tag_options'] )  && !empty( $options['sailthru_interest_tag_options'] ) ) {
-			$tags_checked = in_array( 'wordpress_tags', $options['sailthru_interest_tag_options'] ) ? true : false;
-			$cat_checked = in_array( 'wordpress_categories', $options['sailthru_interest_tag_options'] ) ? true : false;
+			$tags_checked = in_array( 'wordpress_tags', $options['sailthru_interest_tag_options'], true ) ? true : false;
+			$cat_checked = in_array( 'wordpress_categories', $options['sailthru_interest_tag_options'], true ) ? true : false;
 		}	
 
 		// Do we send this content type? Warn the user if not. 
@@ -63,21 +63,21 @@ class Sailthru_Meta_Box {
 
 		echo '<tr>';
 		echo '<td>';
-		echo '<label for="sailthru_meta_tags" class="sailthru_meta_tags_label" style="padding-bottom:8px; display:block; font-weight:bold">' . __( 'Interest Tags', 'text_domain' ) . '</label>';
+		echo '<label for="sailthru_meta_tags" class="sailthru_meta_tags_label" style="padding-bottom:8px; display:block; font-weight:bold">' . esc_attr__( 'Interest Tags', 'text_domain' ) . '</label>';
 		echo '<input type="text" id="sailthru_meta_tags" name="sailthru_meta_tags" class="sailthru_meta_tags_field widefat" placeholder="' . esc_attr__( '', 'text_domain' ) . '" value="' . esc_attr( $sailthru_meta_tags ) . '">';
-		echo '<p class="description">' . __( 'Comma separated list of tags', 'text_domain' ) . '</p>';
+		echo '<p class="description">' . esc_attr__( 'Comma separated list of tags', 'text_domain' ) . '</p>';
 		echo '</td>';
 		echo '</tr>';		
 
 		if ($tags_checked || $cat_checked) {
 			echo '<tr>';
 			echo '<td>';
-			echo '<small>' . __( 'Your settings include', 'text_domain' ) . '';
+			echo '<small>' . esc_attr__( 'Your settings include', 'text_domain' ) . '';
 
 			if ($cat_checked) {
 				
 				if (true === $cat_checked) {
-					echo  __( 'WordPress categories', 'text_domain' ) ;
+					echo  esc_attr__( 'WordPress categories', 'text_domain' ) ;
 				}
 
 				if ($cat_checked && $tags_checked) {
@@ -85,7 +85,7 @@ class Sailthru_Meta_Box {
 				}
 
 				if (true === $tags_checked) {
-					echo  __( 'WordPress tags', 'text_domain' ) ;
+					echo  esc_attr__( 'WordPress tags', 'text_domain' ) ;
 				}
 
 				echo 'in Sailthru interest tags.</small>';
@@ -97,9 +97,9 @@ class Sailthru_Meta_Box {
 		/* post expiration */ 
 		echo '<tr class="line">';
 		echo '<td>';
-		echo '<label for="sailthru_post_expiration" class="sailthru_post_expiration_label" style="padding-bottom:8px; display:block; font-weight:bold">' . __( 'Content Expires', 'text_domain' ) . '</label>';
+		echo '<label for="sailthru_post_expiration" class="sailthru_post_expiration_label" style="padding-bottom:8px; display:block; font-weight:bold">' . esc_attr__( 'Content Expires', 'text_domain' ) . '</label>';
 		echo '<input type="date" id="sailthru_post_expiration" name="sailthru_post_expiration" class="sailthru_post_expiration_field" placeholder="' . esc_attr__( '', 'text_domain' ) . '" value="' . esc_attr( $sailthru_post_expiration ) . '">';
-		echo '<p class="description">' . __( 'Do not recommend this content after above date', 'text_domain' ) . '</p>';
+		echo '<p class="description">' . esc_attr__( 'Do not recommend this content after above date', 'text_domain' ) . '</p>';
 		echo '</td>';
 		echo '</tr>';
 

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name: Sailthru for WordPress
 Plugin URI: http://sailthru.com/
 Description: Add the power of Sailthru to your WordPress set up.
-Version: 3.3-beta
+Version: 3.3.0
 Author: Sailthru
 Author URI: http://sailthru.com
 Author Email: integrations@sailthru.com
@@ -35,7 +35,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  * @var   const    $version    The current version of the plugin.
  */
 if ( ! defined( 'SAILTHRU_PLUGIN_VERSION' ) ) {
-	define( 'SAILTHRU_PLUGIN_VERSION', '3.3-beta' );
+	define( 'SAILTHRU_PLUGIN_VERSION', '3.3.0' );
 }
 
 if ( ! defined( 'SAILTHRU_PLUGIN_PATH' ) ) {

--- a/views/admin.functions.php
+++ b/views/admin.functions.php
@@ -355,10 +355,10 @@ function sailthru_admin_tabs($active_tab = '') {
 	$content_active = 'sailthru_content_settings' === $active_tab ? $css_class : '';
 	
 	echo '<h2 class="nav-tab-wrapper">';
-	echo '<a href=" '. admin_url('admin.php?page=sailthru_configuration_page') . ' " class="nav-tab'. esc_attr( $config_active ) . ' ">Configuration</a>';
+	echo '<a href=" '. admin_url( esc_url( 'admin.php?page=sailthru_configuration_page') ) . ' " class="nav-tab'. esc_attr( $config_active ) . ' ">Configuration</a>';
 	if ( sailthru_verify_setup() ) { 
-		echo '<a href=" '. admin_url('admin.php?page=custom_fields_configuration_page') . ' " class="nav-tab'. esc_attr( $list_active ) . ' ">List Signup Options</a>';
-		echo '<a href=" '. admin_url('admin.php?page=sailthru_content_settings') . ' " class="nav-tab'. esc_attr( $content_active ) . ' ">Content Settings</a>';
+		echo '<a href=" '. admin_url( esc_url( 'admin.php?page=custom_fields_configuration_page' ) ) . ' " class="nav-tab'. esc_attr( $list_active ) . ' ">List Signup Options</a>';
+		echo '<a href=" '. admin_url( esc_url( 'admin.php?page=sailthru_content_settings' ) ) . ' " class="nav-tab'. esc_attr( $content_active ) . ' ">Content Settings</a>';
 	}
 	echo '</h2>';
 


### PR DESCRIPTION
Cleans up code styles issues with [3.3-beta,](https://github.com/sailthru/sailthru-wordpress-plugin/tree/3.3-beta) which added content settings section to the setup and migrated some horizon code to a common content class. 

3.3.0 features:
* Add abilility to combine WordPress tags with Sailthru interest tags via a UI setting
* Added abilility to combine categories with Sailthru interest tags via a UI setting
* Added ability to add any available taxonomy to Sailthru tags via the UI
* Added a global whitelist of vars to be included in content api posts
* Added a global tag option so a tag can be added to every post. 
* Added ability to turn on/off Content API syncing via the UI. 

