### PR TITLE
Option in Sailthru subscribe widget/shortcode for resetting user optout status on subscribe

### DIFF
--- a/views/widget.subscribe.admin.php
+++ b/views/widget.subscribe.admin.php
@@ -50,6 +50,12 @@
 					<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'source' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'source' ) ); ?>" type="text" value="<?php echo esc_attr( $source ); ?>" />
 				</label>
 			</p>
+			<p>
+				<span>
+					<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'reset_optout_status' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'reset_optout_status' ) ); ?>" type="checkbox" <?php echo ( $instance[ 'reset_optout_status' ] ) ? 'checked' : '' ?> />
+					Reset user optout status on form submission
+				</span>
+			</p>
 			  <p>
 				<label for="<?php echo esc_attr( $this->get_field_id( 'event_name' ) ); ?>">
 					<?php esc_html_e( 'Lifecycle Optimizer Event Name' ); ?>

--- a/views/widget.subscribe.display.php
+++ b/views/widget.subscribe.display.php
@@ -9,6 +9,7 @@
 	$title         = empty( $instance['title'] ) ? ' ' : apply_filters( 'widget_title', esc_attr( $instance['title'] ) );
 	$source        = empty( $instance['source'] ) ? get_bloginfo( 'url' ) : esc_attr( $instance['source'] );
 	$lo_event_name = empty( $instance['lo_event_name'] ) ? '' : esc_attr( $instance['lo_event_name'] );
+	$reset_optout_status = empty( $instance['reset_optout_status'] ) ? '' : esc_attr( $instance['reset_optout_status'] );
 
 if ( ! empty( $instance['sailthru_list'] ) ) {
 	if ( is_array( $instance['sailthru_list'] ) ) {
@@ -355,6 +356,8 @@ if ( ! empty( $instance['sailthru_list'] ) ) {
 				<input type="hidden" name="action" value="add_subscriber" />
 				<input type="hidden" name="source" value="<?php echo esc_attr( $source ); ?>" />
 				<input type="hidden" name="lo_event_name" value="<?php echo esc_attr( $lo_event_name ); ?>" />
+				<input type="hidden" name="reset_optout_status" value="<?php echo esc_attr( $reset_optout_status ) ?>" />
+				<input type="hidden" name="captcha_token" value="" id="token" />
 
 				<span class="input-group-btn">
 					<button class="btn btn-reverse" type="submit">
@@ -363,4 +366,13 @@ if ( ! empty( $instance['sailthru_list'] ) ) {
 				</span>
 		</form>
 	</div>
+	<script src="https://www.google.com/recaptcha/api.js?render=6LcV750UAAAAAOE4DIrJhklurhXd8apQRqUOwVHn"></script>
+				<script>
+					grecaptcha.ready(function() {
+						grecaptcha.execute('6LcV750UAAAAAOE4DIrJhklurhXd8apQRqUOwVHn', {action: 'homepage'}).then(function(token) {
+							var captchaToken = document.getElementById("token");
+							captchaToken.value = token;
+						});
+					});
+				</script>
 </div>

--- a/widget.subscribe.php
+++ b/widget.subscribe.php
@@ -414,6 +414,17 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 				}
 			}
 
+			if ( isset ( $_POST['captcha_token'] ) && ! empty( $_POST['captcha_token'] ) ) {
+				try {
+					$response = wp_remote_get( 'https://www.google.com/recaptcha/api/siteverify?secret=6LcV750UAAAAAMovExQ83JGQY5Z2v5uYQGN_fRI0&response=' . $_POST['captcha_token'] );
+					if ( false == $response['body']['success'] ) {
+						throw new Exception( 'User failed reCaptcha test' );
+					}
+				} catch (Exception $e) {
+					write_log( $e->getMessage() );
+				}
+			}
+
 			if ( isset( $_POST['reset_optout_status'] ) && ! empty( $_POST['reset_optout_status'] ) ) {
 				$reset_optout_status = 'none';
 			} else {
@@ -429,17 +440,6 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 			);
 
 			if ( ! empty( $profile ) ) {
-
-				if ( isset ( $_POST['captcha_token'] ) && ! empty( $_POST['captcha_token'] ) ) {
-					try {
-						$response = wp_remote_get( 'https://www.google.com/recaptcha/api/siteverify?secret=6LcV750UAAAAAMovExQ83JGQY5Z2v5uYQGN_fRI0&response=' . $_POST['captcha_token'] );
-						if ( false == $response['body']['success'] ) {
-							throw new Exception( 'User failed reCaptcha test' );
-						}
-					} catch (Exception $e) {
-						write_log( $e->getMessage() );
-					}
-				}
 
 				if ( isset( $profile['lists'] ) && count( $profile['lists'] ) > 0 ) {
 


### PR DESCRIPTION
1) The Sailthru Subscribe widget now has a checkbox that resets user optout status to "none" on subscription to lists/LO flows. 
2) Fixes a bug that was messing up the CSS for the shortcode and was preventing the form in the widget from being submitted.
3) Added reCaptcha to the homepage. The hard-coded secret will be addressed in a later PR.