### PR TITLE
IN-1131 Add Sailthru opt-in reset checkbox to Sailthru Subscribe widget, add optional reCaptcha integration

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: brownac, lcooper, asilverman, nickgundry, sailthru-wp, automattic,
 Tags: personalization, email,
 Requires at least: 3.6
 Tested up to: 4.9.5
-Stable tag: 3.3.1
+Stable tag: 3.4.0
 
 This plugin  provides fast and easy integration of the core Sailthru features into your Wordpress site.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,13 @@
 # Changelog
+
+## v.3.4.0
+Added the option to reset user optout status on newsletter subscription. Appears as a checkbox in the footer widget and as the following option in the shortcode:
+```
+[sailthru_widget ... reset_optout_status="on"]
+```
+
+Enabling this option will change the user's optout status to "valid" in Sailthru by passing the `optout_email=none` option in the API.
+
 ## v3.3.0 (2018-11-12)
 Address codestyle issues for VIP
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 ## v.3.4.0
 Added the option to reset user optout status on newsletter subscription. Appears as a checkbox in the footer widget and as the following option in the shortcode:
 ```
-[sailthru_widget ... reset_optout_status="on"]
+[sailthru_widget ... reset_optout_status="true"]
 ```
 
 Enabling this option will change the user's optout status to "valid" in Sailthru by passing the `optout_email=none` option in the API.

--- a/classes/class-sailthru-horizon.php
+++ b/classes/class-sailthru-horizon.php
@@ -311,8 +311,8 @@ class Sailthru_Horizon {
 
 			$scout_menu                       = add_submenu_page(
 				'sailthru_configuration_page',
-				__( 'List Signup Options', 'sailthru-for-wordpress' ),
-				__( 'List Signup Options', 'sailthru-for-wordpress' ),
+				__( 'Customer Signup Options', 'sailthru-for-wordpress' ),
+				__( 'Customer Signup Options', 'sailthru-for-wordpress' ),
 				'manage_options',
 				'custom_fields_configuration_page',
 				array( $this, 'load_sailthru_admin_display' )

--- a/css/widget.subscribe.css
+++ b/css/widget.subscribe.css
@@ -83,3 +83,12 @@
   -moz-box-shadow: 3px 3px 3px 3px #ebebeb;
   -webkit-box-shadow: 3px 3px 3px 3px #ebebeb;
   box-shadow: 3px 3px 3px 3px #ebebeb; }
+
+  .grecaptcha-badge {
+    visibility: hidden;
+  }
+
+  .captcha-disclaimer {
+    font-size: 14px;
+    opacity: 0.7;
+  }

--- a/js/widget.subscribe.js
+++ b/js/widget.subscribe.js
@@ -23,12 +23,13 @@
 		$(".sailthru-add-subscriber-form").submit( async function( e ){
 
 			e.preventDefault();
-			// add the captcha token since the expiry is only 2 minutes
-			var recaptcha = $("#token");
+			var recaptcha = $("#sailthruToken");
 			var siteKey = $("#siteKey").val();
-			var token = await grecaptcha.execute(siteKey, {action: 'homepage'});
-			recaptcha.val(token);
-		  
+            if (recaptcha.val()) {
+                var token = await grecaptcha.execute(siteKey, {action: 'homepage'});
+                recaptcha.val(token);
+            }
+
 			var user_input = $(this).serialize();
 			var form = $(this);
 			$.ajax({

--- a/js/widget.subscribe.js
+++ b/js/widget.subscribe.js
@@ -20,7 +20,7 @@
 		}) ;
 
 		// when a user clicks subscribe
-		$(".sailthru-add-subscriber-form").submit( async function( e ){
+		$(".sailthru-add-subscriber-form").submit(async function(e){
 
 			e.preventDefault();
 			var recaptcha = $("#sailthruToken");

--- a/js/widget.subscribe.js
+++ b/js/widget.subscribe.js
@@ -25,10 +25,10 @@
 			e.preventDefault();
 			var recaptcha = $("#sailthruToken");
 			var siteKey = $("#siteKey").val();
-		    	if (!recaptcha.val()) {
-			    var token = await grecaptcha.execute(siteKey, {action: 'homepage'});
-			    recaptcha.val(token);
-		    	}
+		  if (!recaptcha.val() && siteKey) {
+			 var token = await grecaptcha.execute(siteKey, {action: 'homepage'});
+			 recaptcha.val(token);
+		  }
 
 			var user_input = $(this).serialize();
 			var form = $(this);

--- a/js/widget.subscribe.js
+++ b/js/widget.subscribe.js
@@ -20,9 +20,15 @@
 		}) ;
 
 		// when a user clicks subscribe
-		$(".sailthru-add-subscriber-form").submit( function( e ){
+		$(".sailthru-add-subscriber-form").submit( async function( e ){
 
 			e.preventDefault();
+			// add the captcha token since the expiry is only 2 minutes
+			var recaptcha = $("#token");
+			var siteKey = $("#siteKey").val();
+			var token = await grecaptcha.execute(siteKey, {action: 'homepage'});
+			recaptcha.val(token);
+		  
 			var user_input = $(this).serialize();
 			var form = $(this);
 			$.ajax({

--- a/js/widget.subscribe.js
+++ b/js/widget.subscribe.js
@@ -25,10 +25,10 @@
 			e.preventDefault();
 			var recaptcha = $("#sailthruToken");
 			var siteKey = $("#siteKey").val();
-		  if (!recaptcha.val() && siteKey) {
-			 var token = await grecaptcha.execute(siteKey, {action: 'homepage'});
-			 recaptcha.val(token);
-		  }
+		  	if (!recaptcha.val() && siteKey) {
+				var token = await grecaptcha.execute(siteKey, {action: 'homepage'});
+			 	recaptcha.val(token);
+		  	}
 
 			var user_input = $(this).serialize();
 			var form = $(this);

--- a/js/widget.subscribe.js
+++ b/js/widget.subscribe.js
@@ -25,7 +25,7 @@
 			e.preventDefault();
 			var recaptcha = $("#sailthruToken");
 			var siteKey = $("#siteKey").val();
-            if (recaptcha.val()) {
+            if (!recaptcha.val()) {
                 var token = await grecaptcha.execute(siteKey, {action: 'homepage'});
                 recaptcha.val(token);
             }

--- a/js/widget.subscribe.js
+++ b/js/widget.subscribe.js
@@ -25,10 +25,10 @@
 			e.preventDefault();
 			var recaptcha = $("#sailthruToken");
 			var siteKey = $("#siteKey").val();
-            if (!recaptcha.val()) {
-                var token = await grecaptcha.execute(siteKey, {action: 'homepage'});
-                recaptcha.val(token);
-            }
+		    	if (!recaptcha.val()) {
+			    var token = await grecaptcha.execute(siteKey, {action: 'homepage'});
+			    recaptcha.val(token);
+		    	}
 
 			var user_input = $(this).serialize();
 			var form = $(this);

--- a/plugin.php
+++ b/plugin.php
@@ -35,7 +35,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  * @var   const    $version    The current version of the plugin.
  */
 if ( ! defined( 'SAILTHRU_PLUGIN_VERSION' ) ) {
-	define( 'SAILTHRU_PLUGIN_VERSION', '3.3.1' );
+	define( 'SAILTHRU_PLUGIN_VERSION', '3.4.0' );
 }
 
 if ( ! defined( 'SAILTHRU_PLUGIN_PATH' ) ) {

--- a/views/admin.functions.php
+++ b/views/admin.functions.php
@@ -59,12 +59,10 @@ function sailthru_html_hidden_text_input_callback( $args ) {
 	$options = get_option( $collection );
 
 	// Make sure the element is defined in the options. If not, we'll use the preferred default.
-	$value = '';
-	if ( isset( $options[ $option_name ] ) ) {
-		$value = $options[ $option_name ];
-	} else {
-		$value = $default_value;
-	}
+    $value = $default_value;
+    if ( isset( $options[ $option_name ] ) ) {
+        $value = $options[ $option_name ];
+    }
 	echo '<input type="password" id="' . esc_attr( $html_id ) . '" name="' . esc_attr( $collection ) . '[' . esc_attr( $option_name ) . ']" value="' . esc_attr( $value ) . '" class="regular-text" />';
 
 } // end sailthru_html_hidden_text_input_callback

--- a/views/admin.functions.php
+++ b/views/admin.functions.php
@@ -59,10 +59,10 @@ function sailthru_html_hidden_text_input_callback( $args ) {
 	$options = get_option( $collection );
 
 	// Make sure the element is defined in the options. If not, we'll use the preferred default.
-    $value = $default_value;
-    if ( isset( $options[ $option_name ] ) ) {
-        $value = $options[ $option_name ];
-    }
+	$value = $default_value;
+	if ( isset( $options[ $option_name ] ) ) {
+		$value = $options[ $option_name ];
+	}
 	echo '<input type="password" id="' . esc_attr( $html_id ) . '" name="' . esc_attr( $collection ) . '[' . esc_attr( $option_name ) . ']" value="' . esc_attr( $value ) . '" class="regular-text" />';
 
 } // end sailthru_html_hidden_text_input_callback

--- a/views/admin.functions.php
+++ b/views/admin.functions.php
@@ -49,6 +49,26 @@ function sailthru_html_text_input_callback( $args ) {
 
 } // end sailthru_html_text_input_callback.
 
+function sailthru_html_hidden_text_input_callback( $args ) {
+
+	$collection    = $args[0];
+	$option_name   = $args[1];
+	$default_value = $args[2];
+	$html_id       = $args[3];
+
+	$options = get_option( $collection );
+
+	// Make sure the element is defined in the options. If not, we'll use the preferred default.
+	$value = '';
+	if ( isset( $options[ $option_name ] ) ) {
+		$value = $options[ $option_name ];
+	} else {
+		$value = $default_value;
+	}
+	echo '<input type="password" id="' . esc_attr( $html_id ) . '" name="' . esc_attr( $collection ) . '[' . esc_attr( $option_name ) . ']" value="' . esc_attr( $value ) . '" class="regular-text" />';
+
+} // end sailthru_html_hidden_text_input_callback
+
 
 /**
  * This function renders the interface elements for toggling a feature on or off.

--- a/views/admin.functions.php
+++ b/views/admin.functions.php
@@ -357,7 +357,7 @@ function sailthru_admin_tabs($active_tab = '') {
 	echo '<h2 class="nav-tab-wrapper">';
 	echo '<a href=" '. admin_url( esc_url( 'admin.php?page=sailthru_configuration_page') ) . ' " class="nav-tab'. esc_attr( $config_active ) . ' ">Configuration</a>';
 	if ( sailthru_verify_setup() ) { 
-		echo '<a href=" '. admin_url( esc_url( 'admin.php?page=custom_fields_configuration_page' ) ) . ' " class="nav-tab'. esc_attr( $list_active ) . ' ">List Signup Options</a>';
+		echo '<a href=" '. admin_url( esc_url( 'admin.php?page=custom_fields_configuration_page' ) ) . ' " class="nav-tab'. esc_attr( $list_active ) . ' ">Customer Signup Options</a>';
 		echo '<a href=" '. admin_url( esc_url( 'admin.php?page=sailthru_content_settings' ) ) . ' " class="nav-tab'. esc_attr( $content_active ) . ' ">Content Settings</a>';
 	}
 	echo '</h2>';

--- a/views/admin.functions.setup.options.php
+++ b/views/admin.functions.setup.options.php
@@ -252,7 +252,7 @@ function sailthru_initialize_setup_options() {
 		add_settings_field(
 			'google_recaptcha_site_key',
 			__( 'reCaptcha Site Key', 'sailthru-for-wordpress' ),
-			'sailthru_html_text_input_callback',
+			'sailthru_html_hidden_text_input_callback',
 			'sailthru_setup_options',
 			'recaptcha_setup_section',
 			array(
@@ -266,7 +266,7 @@ function sailthru_initialize_setup_options() {
 		add_settings_field(
 			'google_recaptcha_secret',
 			__( 'reCaptcha Secret Key', 'sailthru-for-wordpress' ),
-			'sailthru_html_text_input_callback',
+			'sailthru_html_hidden_text_input_callback',
 			'sailthru_setup_options',
 			'recaptcha_setup_section',
 			array(

--- a/views/admin.functions.setup.options.php
+++ b/views/admin.functions.setup.options.php
@@ -252,7 +252,7 @@ function sailthru_initialize_setup_options() {
 		add_settings_field(
 			'google_recaptcha_site_key',
 			__( 'reCaptcha Site Key', 'sailthru-for-wordpress' ),
-			'sailthru_html_hidden_text_input_callback',
+			'sailthru_html_text_input_callback',
 			'sailthru_setup_options',
 			'recaptcha_setup_section',
 			array(
@@ -349,7 +349,7 @@ function sailthru_setup_callback() {
 
 function recaptcha_setup_callback() {
 	echo '<h3 class="sailthru-sub-section">reCaptcha Site Key and Secret</h3>';
-	echo '<p>(Optional) Add reCaptcha to your signup forms to detect potential spamming and bots. <a href="https://www.google.com/recaptcha/intro/v3.html">Visit the reCaptcha homepage</a> to set up a site key and secret.</p>';
+	echo '<p>(Optional) Add reCaptcha to your signup forms to detect potential spamming and bots. <a href="https://www.google.com/recaptcha/intro/v3.html" target="_blank">Visit the reCaptcha homepage</a> to set up a site key and secret.</p>';
 }
 
 

--- a/views/admin.functions.setup.options.php
+++ b/views/admin.functions.setup.options.php
@@ -691,8 +691,15 @@ function sailthru_setup_handler( $input ) {
 	}
 
 	// recaptcha settings
-	$output['google_recaptcha_site_key'] = isset( $input['google_recaptcha_site_key'] ) ? filter_var( $input['google_recaptcha_site_key'], FILTER_SANITIZE_STRING ) : '';
-	$output['google_recaptcha_secret'] = isset( $input['google_recaptcha_secret'] ) ? filter_var( $input['google_recaptcha_secret'], FILTER_SANITIZE_STRING ) : '';
+    $output['google_recaptcha_site_key'] = '';
+    if ( isset( $input['google_recaptcha_site_key'] ) ) {
+        $output['google_recaptcha_site_key'] = filter_var( $input['google_recaptcha_site_key'], FILTER_SANITIZE_STRING );
+    }
+
+    $output['google_recaptcha_secret'] = '';
+    if ( isset( $input['google_recaptcha_secret'] ) ) {
+        $output['google_recaptcha_secret'] = filter_var( $input['google_recaptcha_secret'], FILTER_SANITIZE_STRING );
+    }
 
 	// javascript type
 	if ( isset( $input['sailthru_js_type'] ) ) {

--- a/views/admin.functions.setup.options.php
+++ b/views/admin.functions.setup.options.php
@@ -691,8 +691,8 @@ function sailthru_setup_handler( $input ) {
 	}
 
 	// recaptcha settings
-	$output['google_recaptcha_site_key'] = isset( $input['google_recaptcha_site_key'] ) ? filter_var( $input['google_recaptcha_site_key'], FILTER_SANITIZE_STRING ) : null;
-	$output['google_recaptcha_secret'] = isset( $input['google_recaptcha_secret'] ) ? filter_var( $input['google_recaptcha_secret'], FILTER_SANITIZE_STRING ) : null;
+	$output['google_recaptcha_site_key'] = isset( $input['google_recaptcha_site_key'] ) ? filter_var( $input['google_recaptcha_site_key'], FILTER_SANITIZE_STRING ) : '';
+	$output['google_recaptcha_secret'] = isset( $input['google_recaptcha_secret'] ) ? filter_var( $input['google_recaptcha_secret'], FILTER_SANITIZE_STRING ) : '';
 
 	// javascript type
 	if ( isset( $input['sailthru_js_type'] ) ) {

--- a/views/admin.functions.setup.options.php
+++ b/views/admin.functions.setup.options.php
@@ -145,6 +145,41 @@ function sailthru_initialize_setup_options() {
 		}
 
 		add_settings_section(
+			'recaptcha_setup_section',   // ID used to identify this section and with which to register options
+			__( '', 'sailthru-for-wordpress' ),    // Title to be displayed on the administration page
+			'recaptcha_setup_callback',   // Callback used to render the description of the section
+			'sailthru_setup_options'   // Page on which to add this section of options
+		);
+	
+		add_settings_field(
+			'google_recaptcha_site_key',
+			__( 'reCaptcha Site Key', 'sailthru-for-wordpress' ),
+			'sailthru_html_text_input_callback',
+			'sailthru_setup_options',
+			'recaptcha_setup_section',
+			array(
+				'sailthru_setup_options',
+				'google_recaptcha_site_key',
+				'',
+				'google_recaptcha_site_key',
+			)
+		);
+	
+		add_settings_field(
+			'google_recaptcha_secret',
+			__( 'reCaptcha Secret Key', 'sailthru-for-wordpress' ),
+			'sailthru_html_text_input_callback',
+			'sailthru_setup_options',
+			'recaptcha_setup_section',
+			array(
+				'sailthru_setup_options',
+				'google_recaptcha_secret',
+				'',
+				'google_recaptcha_secret',
+			)
+		);
+
+		add_settings_section(
 			'sailthru_js_setup_section',   // ID used to identify this section and with which to register options
 			__( '', 'sailthru-for-wordpress' ),    // Title to be displayed on the administration page
 			'sailthru_js_setup_section_callback',   // Callback used to render the description of the section
@@ -311,6 +346,11 @@ function sailthru_setup_callback() {
 	echo '<div id="icon-options-general"><h3>API Keys</h3></div>';
 	echo '<p>Add your Sailthru API key & Secret, you can find this on the <a href="https://my.sailthru.com/settings_api">settings page</a> of the Sailthru dashboard.</p><p>Not sure what these are? Contact <a href="mailto:support@sailthru.com">support@sailthru.com</a> ';
 } // end sailthru_setup_callback
+
+function recaptcha_setup_callback() {
+	echo '<h3 class="sailthru-sub-section">reCaptcha Site Key and Secret</h3>';
+	echo '<p>(Optional) Add reCaptcha to your page to detect potential spamming and bots. <a href="https://www.google.com/recaptcha/intro/v3.html">Visit the reCaptcha homepage</a> to set up a site key and secret.</p>';
+}
 
 
 /* ------------------------------------------------------------------------ *
@@ -650,6 +690,9 @@ function sailthru_setup_handler( $input ) {
 		}
 	}
 
+	// recaptcha settings
+	$output['google_recaptcha_site_key'] = isset( $input['google_recaptcha_site_key'] ) ? filter_var( $input['google_recaptcha_site_key'], FILTER_SANITIZE_STRING ) : null;
+	$output['google_recaptcha_secret'] = isset( $input['google_recaptcha_secret'] ) ? filter_var( $input['google_recaptcha_secret'], FILTER_SANITIZE_STRING ) : null;
 
 	// javascript type
 	if ( isset( $input['sailthru_js_type'] ) ) {

--- a/views/admin.functions.setup.options.php
+++ b/views/admin.functions.setup.options.php
@@ -145,41 +145,6 @@ function sailthru_initialize_setup_options() {
 		}
 
 		add_settings_section(
-			'recaptcha_setup_section',   // ID used to identify this section and with which to register options
-			__( '', 'sailthru-for-wordpress' ),    // Title to be displayed on the administration page
-			'recaptcha_setup_callback',   // Callback used to render the description of the section
-			'sailthru_setup_options'   // Page on which to add this section of options
-		);
-	
-		add_settings_field(
-			'google_recaptcha_site_key',
-			__( 'reCaptcha Site Key', 'sailthru-for-wordpress' ),
-			'sailthru_html_text_input_callback',
-			'sailthru_setup_options',
-			'recaptcha_setup_section',
-			array(
-				'sailthru_setup_options',
-				'google_recaptcha_site_key',
-				'',
-				'google_recaptcha_site_key',
-			)
-		);
-	
-		add_settings_field(
-			'google_recaptcha_secret',
-			__( 'reCaptcha Secret Key', 'sailthru-for-wordpress' ),
-			'sailthru_html_text_input_callback',
-			'sailthru_setup_options',
-			'recaptcha_setup_section',
-			array(
-				'sailthru_setup_options',
-				'google_recaptcha_secret',
-				'',
-				'google_recaptcha_secret',
-			)
-		);
-
-		add_settings_section(
 			'sailthru_js_setup_section',   // ID used to identify this section and with which to register options
 			__( '', 'sailthru-for-wordpress' ),    // Title to be displayed on the administration page
 			'sailthru_js_setup_section_callback',   // Callback used to render the description of the section
@@ -278,6 +243,41 @@ function sailthru_initialize_setup_options() {
 		}
 
 		add_settings_section(
+			'recaptcha_setup_section',   // ID used to identify this section and with which to register options
+			__( '', 'sailthru-for-wordpress' ),    // Title to be displayed on the administration page
+			'recaptcha_setup_callback',   // Callback used to render the description of the section
+			'sailthru_setup_options'   // Page on which to add this section of options
+		);
+	
+		add_settings_field(
+			'google_recaptcha_site_key',
+			__( 'reCaptcha Site Key', 'sailthru-for-wordpress' ),
+			'sailthru_html_text_input_callback',
+			'sailthru_setup_options',
+			'recaptcha_setup_section',
+			array(
+				'sailthru_setup_options',
+				'google_recaptcha_site_key',
+				'',
+				'google_recaptcha_site_key',
+			)
+		);
+	
+		add_settings_field(
+			'google_recaptcha_secret',
+			__( 'reCaptcha Secret Key', 'sailthru-for-wordpress' ),
+			'sailthru_html_text_input_callback',
+			'sailthru_setup_options',
+			'recaptcha_setup_section',
+			array(
+				'sailthru_setup_options',
+				'google_recaptcha_secret',
+				'',
+				'google_recaptcha_secret',
+			)
+		);
+
+		add_settings_section(
 			'sailthru_email_setup_section',   // ID used to identify this section and with which to register options
 			__( '', 'sailthru-for-wordpress' ),    // Title to be displayed on the administration page
 			'sailthru_email_section_callback',   // Callback used to render the description of the section
@@ -349,7 +349,7 @@ function sailthru_setup_callback() {
 
 function recaptcha_setup_callback() {
 	echo '<h3 class="sailthru-sub-section">reCaptcha Site Key and Secret</h3>';
-	echo '<p>(Optional) Add reCaptcha to your page to detect potential spamming and bots. <a href="https://www.google.com/recaptcha/intro/v3.html">Visit the reCaptcha homepage</a> to set up a site key and secret.</p>';
+	echo '<p>(Optional) Add reCaptcha to your signup forms to detect potential spamming and bots. <a href="https://www.google.com/recaptcha/intro/v3.html">Visit the reCaptcha homepage</a> to set up a site key and secret.</p>';
 }
 
 

--- a/views/widget.subscribe.admin.php
+++ b/views/widget.subscribe.admin.php
@@ -1,5 +1,4 @@
 <div id="icon-sailthru" class="icon32"></div>
-	<h2><?php esc_html_e( 'Sailthru Subscribe', 'sailthru-for-wordpress' ); ?></h2>
 
 	<?php
 
@@ -53,7 +52,7 @@
 			<p>
 				<span>
 					<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'reset_optout_status' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'reset_optout_status' ) ); ?>" type="checkbox" <?php echo ( $instance[ 'reset_optout_status' ] ) ? 'checked' : '' ?> />
-					Reset user optout status on form submission
+					Set previously opted-out customers to valid
 				</span>
 			</p>
 			  <p>
@@ -62,6 +61,9 @@
 					<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'lo_event_name' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'lo_event_name' ) ); ?>" type="text" value="<?php echo esc_attr( $lo_event_name ); ?>" />
 					<small>use event name to start a Lifecycle Optimizer flow</small>
 				</label>
+			</p>
+			<p>
+				<h4>Fields</h4>
 			</p>
 			<p>
 			<?php
@@ -237,6 +239,10 @@
 					?>
 
 					</p>
+			
+			<p>
+				<h4>Lists</h4>
+			</p>
 
 			<?php
 

--- a/views/widget.subscribe.admin.php
+++ b/views/widget.subscribe.admin.php
@@ -50,6 +50,12 @@
 					<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'source' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'source' ) ); ?>" type="text" value="<?php echo esc_attr( $source ); ?>" />
 				</label>
 			</p>
+			<p>
+				<span>
+					<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'reset_optout_status' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'reset_optout_status' ) ); ?>" type="checkbox" <?php echo ( $instance[ 'reset_optout_status' ] ) ? 'checked' : '' ?> />
+					Reset user optout status on form submission
+				</span>
+			</p>
 			  <p>
 				<label for="<?php echo esc_attr( $this->get_field_id( 'event_name' ) ); ?>">
 					<?php esc_html_e( 'Lifecycle Optimizer Event Name' ); ?>

--- a/views/widget.subscribe.display.php
+++ b/views/widget.subscribe.display.php
@@ -367,6 +367,7 @@ if ( ! empty( $instance['sailthru_list'] ) ) {
 				<input type="hidden" name="source" value="<?php echo esc_attr( $source ); ?>" />
 				<input type="hidden" name="lo_event_name" value="<?php echo esc_attr( $lo_event_name ); ?>" />
 				<input type="hidden" name="reset_optout_status" value="<?php echo esc_attr( $reset_optout_status ) ?>" />
+				<input type="hidden" name="site_key" value="<?php echo esc_attr( $sailthru['google_recaptcha_site_key'] ) ?>" id="siteKey" />
 				<input type="hidden" name="captcha_token" value="" id="token" />
 
 				<span class="input-group-btn">
@@ -379,14 +380,6 @@ if ( ! empty( $instance['sailthru_list'] ) ) {
 	<?php
 		if ( ! empty( $sailthru['google_recaptcha_site_key'] ) && ! empty ( $sailthru['google_recaptcha_secret'] ) ) {
 			echo '<script src="https://www.google.com/recaptcha/api.js?render=' . esc_attr( $sailthru['google_recaptcha_site_key'] ) . '"></script>';
-			echo '<script>';
-			echo 'grecaptcha.ready(function() {';
-			echo 'grecaptcha.execute(' . '"' . $sailthru['google_recaptcha_site_key'] . '"' . ', {action: "homepage"}).then(function(token) {';
-			echo 'var recaptcha = document.getElementById("token");';
-			echo 'recaptcha.value = token;';
-			echo '});';
-			echo '});';
-			echo '</script>';
 		}
 	?>
 </div>

--- a/views/widget.subscribe.display.php
+++ b/views/widget.subscribe.display.php
@@ -9,6 +9,7 @@
 	$title         = empty( $instance['title'] ) ? ' ' : apply_filters( 'widget_title', esc_attr( $instance['title'] ) );
 	$source        = empty( $instance['source'] ) ? get_bloginfo( 'url' ) : esc_attr( $instance['source'] );
 	$lo_event_name = empty( $instance['lo_event_name'] ) ? '' : esc_attr( $instance['lo_event_name'] );
+	$reset_optout_status = empty( $instance['reset_optout_status'] ) ? '' : esc_attr( $instance['reset_optout_status'] );
 
 if ( ! empty( $instance['sailthru_list'] ) ) {
 	if ( is_array( $instance['sailthru_list'] ) ) {
@@ -355,6 +356,8 @@ if ( ! empty( $instance['sailthru_list'] ) ) {
 				<input type="hidden" name="action" value="add_subscriber" />
 				<input type="hidden" name="source" value="<?php echo esc_attr( $source ); ?>" />
 				<input type="hidden" name="lo_event_name" value="<?php echo esc_attr( $lo_event_name ); ?>" />
+				<input type="hidden" name="reset_optout_status" value="<?php echo esc_attr( $reset_optout_status ) ?>" />
+				<input type="hidden" name="captcha_token" value="" id="token" />
 
 				<span class="input-group-btn">
 					<button class="btn btn-reverse" type="submit">
@@ -363,4 +366,13 @@ if ( ! empty( $instance['sailthru_list'] ) ) {
 				</span>
 		</form>
 	</div>
+	<script src="https://www.google.com/recaptcha/api.js?render=<?php echo esc_attr( $sailthru['google_recaptcha_site_key'] ) ?>"></script>
+				<script>
+					grecaptcha.ready(function() {
+						grecaptcha.execute("<?php echo esc_attr( $sailthru['google_recaptcha_site_key'] ) ?>", {action: 'homepage'}).then(function(token) {
+							var captchaToken = document.getElementById("token");
+							captchaToken.value = token;
+						});
+					});
+				</script>
 </div>

--- a/views/widget.subscribe.display.php
+++ b/views/widget.subscribe.display.php
@@ -351,6 +351,16 @@ if ( ! empty( $instance['sailthru_list'] ) ) {
 					} // end for
 				} // end if there are fields
 				?>
+
+
+				<?php
+					if ( ! empty( $sailthru['google_recaptcha_site_key'] ) && ! empty ( $sailthru['google_recaptcha_secret'] ) ) {
+						echo '<p class="captcha-disclaimer">
+						This site is protected by reCAPTCHA and the Google <a href="https://policies.google.com/privacy">Privacy Policy</a> and
+						<a href="https://policies.google.com/terms">Terms of Service</a> apply.
+						</p>';
+					}
+				?>
 				<input type="hidden" name="sailthru_nonce" value="<?php echo esc_attr( $nonce) ; ?>" />
 				<input type="hidden" name="sailthru_email_list" value="<?php echo esc_attr( $sailthru_list ); ?>" />
 				<input type="hidden" name="action" value="add_subscriber" />

--- a/views/widget.subscribe.display.php
+++ b/views/widget.subscribe.display.php
@@ -367,7 +367,7 @@ if ( ! empty( $instance['sailthru_list'] ) ) {
 		</form>
 	</div>
 	<?php
-		if ( isset( $sailthru['google_recaptcha_site_key'] ) && ! empty( $sailthru['google_recaptcha_site_key'] ) ) {
+		if ( ! empty( $sailthru['google_recaptcha_site_key'] ) && ! empty ( $sailthru['google_recaptcha_secret'] ) ) {
 			echo '<script src="https://www.google.com/recaptcha/api.js?render=' . esc_attr( $sailthru['google_recaptcha_site_key'] ) . '"></script>';
 			echo '<script>';
 			echo 'grecaptcha.ready(function() {';

--- a/views/widget.subscribe.display.php
+++ b/views/widget.subscribe.display.php
@@ -366,13 +366,17 @@ if ( ! empty( $instance['sailthru_list'] ) ) {
 				</span>
 		</form>
 	</div>
-	<script src="https://www.google.com/recaptcha/api.js?render=<?php echo esc_attr( $sailthru['google_recaptcha_site_key'] ) ?>"></script>
-				<script>
-					grecaptcha.ready(function() {
-						grecaptcha.execute("<?php echo esc_attr( $sailthru['google_recaptcha_site_key'] ) ?>", {action: 'homepage'}).then(function(token) {
-							var captchaToken = document.getElementById("token");
-							captchaToken.value = token;
-						});
-					});
-				</script>
+	<?php
+		if ( isset( $sailthru['google_recaptcha_site_key'] ) && ! empty( $sailthru['google_recaptcha_site_key'] ) ) {
+			echo '<script src="https://www.google.com/recaptcha/api.js?render=' . esc_attr( $sailthru['google_recaptcha_site_key'] ) . '"></script>';
+			echo '<script>';
+			echo 'grecaptcha.ready(function() {';
+			echo 'grecaptcha.execute(' . '"' . $sailthru['google_recaptcha_site_key'] . '"' . ', {action: "homepage"}).then(function(token) {';
+			echo 'var recaptcha = document.getElementById("token");';
+			echo 'recaptcha.value = token;';
+			echo '});';
+			echo '});';
+			echo '</script>';
+		}
+	?>
 </div>

--- a/views/widget.subscribe.display.php
+++ b/views/widget.subscribe.display.php
@@ -368,7 +368,7 @@ if ( ! empty( $instance['sailthru_list'] ) ) {
 				<input type="hidden" name="lo_event_name" value="<?php echo esc_attr( $lo_event_name ); ?>" />
 				<input type="hidden" name="reset_optout_status" value="<?php echo esc_attr( $reset_optout_status ) ?>" />
 				<input type="hidden" name="site_key" value="<?php echo esc_attr( $sailthru['google_recaptcha_site_key'] ) ?>" id="siteKey" />
-				<input type="hidden" name="captcha_token" value="" id="token" />
+				<input type="hidden" name="captcha_token" value="" id="sailthruToken" />
 
 				<span class="input-group-btn">
 					<button class="btn btn-reverse" type="submit">

--- a/widget.subscribe.php
+++ b/widget.subscribe.php
@@ -415,7 +415,9 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 				}
 			}
 
-			if ( ! empty( $sailthru['google_recaptcha_site_key'] ) && ! empty( $sailthru['google_recaptcha_secret'] ) && isset ( $_POST['captcha_token'] ) && ! empty( $_POST['captcha_token'] ) ) {
+            $recaptcha_token = sanitize_text_field( $_POST['captcha_token'] );
+
+			if ( ! empty( $sailthru['google_recaptcha_site_key'] ) && ! empty( $sailthru['google_recaptcha_secret'] ) && ! empty( $recaptcha_token ) ) {
 				write_log( "reCaptcha enabled, verifying" );
 				try {
 					$response = wp_remote_get( 'https://www.google.com/recaptcha/api/siteverify?secret=' . $sailthru['google_recaptcha_secret'] . '&response=' . $_POST['captcha_token'] );

--- a/widget.subscribe.php
+++ b/widget.subscribe.php
@@ -411,7 +411,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 				}
 			}
 
-            $recaptcha_token = sanitize_text_field( $_POST['captcha_token'] );
+            		$recaptcha_token = sanitize_text_field( $_POST['captcha_token'] );
 
 			if ( ! empty( $sailthru['google_recaptcha_site_key'] ) && ! empty( $sailthru['google_recaptcha_secret'] ) && ! empty( $recaptcha_token ) ) {
 				write_log( "reCaptcha enabled, verifying" );

--- a/widget.subscribe.php
+++ b/widget.subscribe.php
@@ -67,10 +67,6 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 			// According to documentation: admin_print_styles should not be used to enqueue styles or scripts on the admin pages. Use admin_enqueue_scripts instead.
 			add_action( 'admin_enqueue_scripts', array( $this, 'register_admin_scripts' ) );
 
-			// Register site styles and scripts
-
-			// Include the Ajax library on the front end
-
 			// Method to subscribe a user
 			add_action( 'wp_ajax_nopriv_add_subscriber', array( $this, 'add_subscriber' ) );
 			add_action( 'wp_ajax_add_subscriber', array( $this, 'add_subscriber' ) );
@@ -420,7 +416,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 			if ( ! empty( $sailthru['google_recaptcha_site_key'] ) && ! empty( $sailthru['google_recaptcha_secret'] ) && ! empty( $recaptcha_token ) ) {
 				write_log( "reCaptcha enabled, verifying" );
 				try {
-					$response = wp_remote_get( 'https://www.google.com/recaptcha/api/siteverify?secret=' . $sailthru['google_recaptcha_secret'] . '&response=' . $_POST['captcha_token'] );
+					$response = wp_remote_get( 'https://www.google.com/recaptcha/api/siteverify?secret=' . $sailthru['google_recaptcha_secret'] . '&response=' . $recaptcha_token );
 					$body = wp_remote_retrieve_body( $response );
 					$data = json_decode( $body, true );
 					if ( false == $data['success'] ) {
@@ -433,16 +429,16 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 						);
 					}
 				} catch ( Exception $e ) {
-					write_log( $e->getMessage() );
+					write_log( $e );
 				}
 			}
 
 			$reset_optout_status = isset( $_POST['reset_optout_status'] ) && ! empty( $_POST['reset_optout_status'] ) ? 'none': '';
 
 			$profile_data = array(
-				'id'    => $email,
-				'key'   => 'email',
-				'vars'  => $options['vars'],
+				'id' => $email,
+				'key' => 'email',
+				'vars' => $options['vars'],
 				'lists' => $options['lists'],
 				'optout_email' => $reset_optout_status
 			);

--- a/widget.subscribe.php
+++ b/widget.subscribe.php
@@ -411,7 +411,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
                 }
             }
 
-                    $recaptcha_token = sanitize_text_field( $_POST['captcha_token'] );
+            $recaptcha_token = sanitize_text_field( $_POST['captcha_token'] );
 
             if ( ! empty( $sailthru['google_recaptcha_site_key'] ) && ! empty( $sailthru['google_recaptcha_secret'] ) && ! empty( $recaptcha_token ) ) {
                 write_log( "reCaptcha enabled, verifying" );

--- a/widget.subscribe.php
+++ b/widget.subscribe.php
@@ -3,7 +3,7 @@
 function sailthru_attributes( $attribute_list ) {
 	if ( ! empty( $attribute_list ) ) {
 		$attributes = explode( ',', $attribute_list );
-		$list	   = '';
+		$list = '';
 		foreach ( $attributes as $attribute ) {
 			$split = explode( ':', esc_attr( $attribute ) );
 			$list .= $split[0] . '="' . $split[1] . '" ';
@@ -112,23 +112,23 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 	public function update( $new_instance, $old_instance ) {
 
 		$instance = array(
-			'title'		 => filter_var( $new_instance['title'], FILTER_SANITIZE_STRING ),
-			'source'		=> filter_var( $new_instance['source'], FILTER_SANITIZE_STRING ),
+			'title' => filter_var( $new_instance['title'], FILTER_SANITIZE_STRING ),
+			'source' => filter_var( $new_instance['source'], FILTER_SANITIZE_STRING ),
 			'lo_event_name' => filter_var( $new_instance['lo_event_name'], FILTER_SANITIZE_STRING ),
 			'reset_optout_status' => filter_var ( $new_instance[ 'reset_optout_status' ], FILTER_SANITIZE_STRING )
 		);
 
 		$customfields = get_option( 'sailthru_forms_options' );
-		$key		  = get_option( 'sailthru_forms_key' );
+		$key = get_option( 'sailthru_forms_key' );
 
 		for ( $i = 0; $i < $key; $i++ ) {
-			$field_key	 = $i + 1;
+			$field_key = $i + 1;
 			$name_stripped = preg_replace( '/[^\da-z]/i', '_', $customfields[ $field_key ]['sailthru_customfield_name'] );
 			//setup instance variables
-			$instance[ 'show_' . $name_stripped . '_name' ]	 = (bool) $new_instance[ 'show_' . $name_stripped . '_name' ];
+			$instance[ 'show_' . $name_stripped . '_name' ] = (bool) $new_instance[ 'show_' . $name_stripped . '_name' ];
 			$instance[ 'show_' . $name_stripped . '_required' ] = (bool) $new_instance[ 'show_' . $name_stripped . '_required' ];
-			$instance[ 'show_' . $name_stripped . '_type' ]	 = $new_instance[ 'show_' . $name_stripped . '_type' ];
-			$instance['field_order']							= $new_instance['field_order'];
+			$instance[ 'show_' . $name_stripped . '_type' ] = $new_instance[ 'show_' . $name_stripped . '_type' ];
+			$instance['field_order'] = $new_instance['field_order'];
 			//$instance['sailthru_customfields_order_widget'] = sanitize_text_field($new_instance['field_order']);
 
 		}
@@ -151,22 +151,22 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 		// Default values for a widget instance
 		$instance = wp_parse_args(
 			(array) $instance, array(
-				'title'		 => '',
-				'source'		=> '',
+				'title' => '',
+				'source' => '',
 				'lo_event_name' => '',
 				'reset_optout_status' => '',
 				'sailthru_list' => array( '' ),
-				'field_order'   => '',
+				'field_order' => '',
 			)
 		);
 
-		$title		 = $instance['title'];
-		$source		= $instance['source'];
+		$title = $instance['title'];
+		$source = $instance['source'];
 		$lo_event_name = $instance['lo_event_name'];
 		$reset_optout_status = $instance['reset_optout_status'];
 		$sailthru_list = $instance['sailthru_list'];
-		$order		 = $field_order = $instance['field_order'];
-		$widget_id	 = $this->id;
+		$order = $field_order = $instance['field_order'];
+		$widget_id = $this->id;
 
 		// Display the admin form
 		include SAILTHRU_PLUGIN_PATH . 'views/widget.subscribe.admin.php';
@@ -214,11 +214,11 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 
 		if ( false === email_exists( $email ) ) {
 			$random_password = wp_generate_password( $length = 12, $include_standard_special_chars = false );
-			$user			= wp_create_user( $email, $random_password, $email );
+			$user = wp_create_user( $email, $random_password, $email );
 			wp_new_user_notification( $user, null, 'user', $params );
 
-			$user_vars			 = $options['vars'];
-			$user_vars['ID']	   = $user;
+			$user_vars  = $options['vars'];
+			$user_vars['ID'] = $user;
 			$user_vars['nickname'] = $first_name . ' ' . $last_name;
 			unset( $user_vars['wp_widget_lists'] );
 			wp_update_user( $user_vars );
@@ -315,15 +315,15 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 		}
 
 		// check if email address exists in Sailthru.
-		$sailthru   = get_option( 'sailthru_setup_options' );
-		$api_key	= $sailthru['sailthru_api_key'];
+		$sailthru = get_option( 'sailthru_setup_options' );
+		$api_key = $sailthru['sailthru_api_key'];
 		$api_secret = $sailthru['sailthru_api_secret'];
 
 		$client = new WP_Sailthru_Client( $api_key, $api_secret );
 
 		if ( $client ) {
 
-			$options	  = array();
+			$options = array();
 
 			// set the source
 			if ( isset( $_POST['source'] ) && ! empty( $_POST['source'] ) ) {
@@ -333,9 +333,9 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 			}
 
 			// initialize vars with source.
-			$vars		 = array( 'source' => $source );
+			$vars = array( 'source' => $source );
 			$customfields = get_option( 'sailthru_forms_options' );
-			$key		  = get_option( 'sailthru_forms_key' );
+			$key = get_option( 'sailthru_forms_key' );
 
 			for ( $i = 0; $i < $key; $i++ ) {
 				$field_key = $i + 1;
@@ -348,11 +348,11 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 						if ( is_array( $_POST[ 'custom_' . $name_stripped ] ) ) {
 
 							foreach ( $_POST[ 'custom_' . $name_stripped ] as $val ) {
-								$var_name			 = str_replace( 'custom_', '', $name_stripped );
+								$var_name = str_replace( 'custom_', '', $name_stripped );
 								$vars[ $var_name ] [] = sanitize_text_field( $val );
 							}
 						} else {
-							$var_name		  = str_replace( 'custom_', '', $name_stripped );
+							$var_name = str_replace( 'custom_', '', $name_stripped );
 							$vars[ $var_name ] = sanitize_text_field( $_POST[ 'custom_' . $name_stripped ] );
 						}
 					}
@@ -393,7 +393,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 			$options['vars'] = $vars;
 
 			$data = array(
-				'id'	 => $email,
+				'id' => $email,
 				'fields' => array(
 					'lists' => 1,
 					'keys'  => 1,
@@ -505,9 +505,9 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 			if ( $event ) {
 
 				$event_data = array(
-					'id'	=> $email,
+					'id' => $email,
 					'event' => $event,
-					'vars'  => $options['vars'],
+					'vars' => $options['vars'],
 				);
 
 				try {
@@ -518,7 +518,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 			}
 
 			if ( has_filter( 'sailthru_user_registration_enable' ) ) {
-				$setup	= get_option( 'sailthru_setup_options' );
+				$setup = get_option( 'sailthru_setup_options' );
 				$template = '';
 				if ( isset( $setup['sailthru_setup_new_user_override_template'] ) && ! empty( $setup['sailthru_setup_new_user_override_template'] ) ) {
 					$template = $setup['sailthru_setup_new_user_override_template'];
@@ -566,11 +566,11 @@ function sailthru_widget_shortcode( $atts ) {
 	extract(
 		shortcode_atts(
 			array(
-				'fields'		  => 'name',
-				'modal'		   => 'false',
-				'text'			=> 'Subscribe',
-				'sailthru_list'   => array(),
-				'field_order'	 => '',
+				'fields' => 'name',
+				'modal' => 'false',
+				'text' => 'Subscribe',
+				'sailthru_list' => array(),
+				'field_order' => '',
 				'using_shortcode' => true,
 			), $atts
 		)

--- a/widget.subscribe.php
+++ b/widget.subscribe.php
@@ -3,7 +3,7 @@
 function sailthru_attributes( $attribute_list ) {
 	if ( ! empty( $attribute_list ) ) {
 		$attributes = explode( ',', $attribute_list );
-		$list = '';
+		$list       = '';
 		foreach ( $attributes as $attribute ) {
 			$split = explode( ':', esc_attr( $attribute ) );
 			$list .= $split[0] . '="' . $split[1] . '" ';
@@ -112,24 +112,25 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 	public function update( $new_instance, $old_instance ) {
 
 		$instance = array(
-			'title' => filter_var( $new_instance['title'], FILTER_SANITIZE_STRING ),
-			'source' => filter_var( $new_instance['source'], FILTER_SANITIZE_STRING ),
-			'lo_event_name' => filter_var( $new_instance['lo_event_name'], FILTER_SANITIZE_STRING ),
+			'title'               => filter_var( $new_instance['title'], FILTER_SANITIZE_STRING ),
+			'source'              => filter_var( $new_instance['source'], FILTER_SANITIZE_STRING ),
+			'lo_event_name'       => filter_var( $new_instance['lo_event_name'], FILTER_SANITIZE_STRING ),
 			'reset_optout_status' => filter_var ( $new_instance[ 'reset_optout_status' ], FILTER_SANITIZE_STRING )
 		);
 
 		$customfields = get_option( 'sailthru_forms_options' );
-		$key = get_option( 'sailthru_forms_key' );
+		$key          = get_option( 'sailthru_forms_key' );
 
 		for ( $i = 0; $i < $key; $i++ ) {
-			$field_key = $i + 1;
+			$field_key     = $i + 1;
 			$name_stripped = preg_replace( '/[^\da-z]/i', '_', $customfields[ $field_key ]['sailthru_customfield_name'] );
+
 			//setup instance variables
-			$instance[ 'show_' . $name_stripped . '_name' ] = (bool) $new_instance[ 'show_' . $name_stripped . '_name' ];
+			$instance[ 'show_' . $name_stripped . '_name' ]     = (bool) $new_instance[ 'show_' . $name_stripped . '_name' ];
 			$instance[ 'show_' . $name_stripped . '_required' ] = (bool) $new_instance[ 'show_' . $name_stripped . '_required' ];
-			$instance[ 'show_' . $name_stripped . '_type' ] = $new_instance[ 'show_' . $name_stripped . '_type' ];
-			$instance['field_order'] = $new_instance['field_order'];
-			//$instance['sailthru_customfields_order_widget'] = sanitize_text_field($new_instance['field_order']);
+			$instance[ 'show_' . $name_stripped . '_type' ]     = $new_instance[ 'show_' . $name_stripped . '_type' ];
+			$instance['field_order']                            = $new_instance['field_order'];
+			// $instance['sailthru_customfields_order_widget']     = sanitize_text_field($new_instance['field_order']);
 
 		}
 		$instance['sailthru_list'] = is_array( $new_instance['sailthru_list'] ) ? array_map( 'sanitize_text_field', $new_instance['sailthru_list'] ) : '';
@@ -151,22 +152,22 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 		// Default values for a widget instance
 		$instance = wp_parse_args(
 			(array) $instance, array(
-				'title' => '',
-				'source' => '',
-				'lo_event_name' => '',
+				'title'               => '',
+				'source'              => '',
+				'lo_event_name'       => '',
 				'reset_optout_status' => '',
-				'sailthru_list' => array( '' ),
-				'field_order' => '',
+				'sailthru_list'       => array( '' ),
+				'field_order'         => '',
 			)
 		);
 
-		$title = $instance['title'];
-		$source = $instance['source'];
-		$lo_event_name = $instance['lo_event_name'];
+		$title               = $instance['title'];
+		$source              = $instance['source'];
+		$lo_event_name       = $instance['lo_event_name'];
 		$reset_optout_status = $instance['reset_optout_status'];
-		$sailthru_list = $instance['sailthru_list'];
-		$order = $field_order = $instance['field_order'];
-		$widget_id = $this->id;
+		$sailthru_list       = $instance['sailthru_list'];
+		$order               = $field_order = $instance['field_order'];
+		$widget_id           = $this->id;
 
 		// Display the admin form
 		include SAILTHRU_PLUGIN_PATH . 'views/widget.subscribe.admin.php';
@@ -214,11 +215,11 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 
 		if ( false === email_exists( $email ) ) {
 			$random_password = wp_generate_password( $length = 12, $include_standard_special_chars = false );
-			$user = wp_create_user( $email, $random_password, $email );
+			$user            = wp_create_user( $email, $random_password, $email );
 			wp_new_user_notification( $user, null, 'user', $params );
 
-			$user_vars  = $options['vars'];
-			$user_vars['ID'] = $user;
+			$user_vars             = $options['vars'];
+			$user_vars['ID']       = $user;
 			$user_vars['nickname'] = $first_name . ' ' . $last_name;
 			unset( $user_vars['wp_widget_lists'] );
 			wp_update_user( $user_vars );
@@ -315,8 +316,8 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 		}
 
 		// check if email address exists in Sailthru.
-		$sailthru = get_option( 'sailthru_setup_options' );
-		$api_key = $sailthru['sailthru_api_key'];
+		$sailthru   = get_option( 'sailthru_setup_options' );
+		$api_key    = $sailthru['sailthru_api_key'];
 		$api_secret = $sailthru['sailthru_api_secret'];
 
 		$client = new WP_Sailthru_Client( $api_key, $api_secret );
@@ -333,9 +334,9 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 			}
 
 			// initialize vars with source.
-			$vars = array( 'source' => $source );
+			$vars         = array( 'source' => $source );
 			$customfields = get_option( 'sailthru_forms_options' );
-			$key = get_option( 'sailthru_forms_key' );
+			$key          = get_option( 'sailthru_forms_key' );
 
 			for ( $i = 0; $i < $key; $i++ ) {
 				$field_key = $i + 1;
@@ -348,11 +349,11 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 						if ( is_array( $_POST[ 'custom_' . $name_stripped ] ) ) {
 
 							foreach ( $_POST[ 'custom_' . $name_stripped ] as $val ) {
-								$var_name = str_replace( 'custom_', '', $name_stripped );
+								$var_name             = str_replace( 'custom_', '', $name_stripped );
 								$vars[ $var_name ] [] = sanitize_text_field( $val );
 							}
 						} else {
-							$var_name = str_replace( 'custom_', '', $name_stripped );
+							$var_name          = str_replace( 'custom_', '', $name_stripped );
 							$vars[ $var_name ] = sanitize_text_field( $_POST[ 'custom_' . $name_stripped ] );
 						}
 					}
@@ -393,7 +394,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 			$options['vars'] = $vars;
 
 			$data = array(
-				'id' => $email,
+				'id'     => $email,
 				'fields' => array(
 					'lists' => 1,
 					'keys'  => 1,
@@ -417,8 +418,8 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 				write_log( "reCaptcha enabled, verifying" );
 				try {
 					$response = wp_remote_get( 'https://www.google.com/recaptcha/api/siteverify?secret=' . $sailthru['google_recaptcha_secret'] . '&response=' . $recaptcha_token );
-					$body = wp_remote_retrieve_body( $response );
-					$data = json_decode( $body, true );
+					$body     = wp_remote_retrieve_body( $response );
+					$data     = json_decode( $body, true );
 					if ( false == $data['success'] ) {
 						// failed, send an error message here, but keep it vague
 						$this->return_response(
@@ -434,9 +435,9 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 			}
 
 			$profile_data = array(
-				'id' => $email,
-				'key' => 'email',
-				'vars' => $options['vars'],
+				'id'    => $email,
+				'key'   => 'email',
+				'vars'  => $options['vars'],
 				'lists' => $options['lists'],
 			);
 
@@ -505,9 +506,9 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 			if ( $event ) {
 
 				$event_data = array(
-					'id' => $email,
+					'id'    => $email,
 					'event' => $event,
-					'vars' => $options['vars'],
+					'vars'  => $options['vars'],
 				);
 
 				try {
@@ -518,7 +519,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 			}
 
 			if ( has_filter( 'sailthru_user_registration_enable' ) ) {
-				$setup = get_option( 'sailthru_setup_options' );
+				$setup    = get_option( 'sailthru_setup_options' );
 				$template = '';
 				if ( isset( $setup['sailthru_setup_new_user_override_template'] ) && ! empty( $setup['sailthru_setup_new_user_override_template'] ) ) {
 					$template = $setup['sailthru_setup_new_user_override_template'];
@@ -566,11 +567,11 @@ function sailthru_widget_shortcode( $atts ) {
 	extract(
 		shortcode_atts(
 			array(
-				'fields' => 'name',
-				'modal' => 'false',
-				'text' => 'Subscribe',
-				'sailthru_list' => array(),
-				'field_order' => '',
+				'fields'          => 'name',
+				'modal'           => 'false',
+				'text'            => 'Subscribe',
+				'sailthru_list'   => array(),
+				'field_order'     => '',
 				'using_shortcode' => true,
 			), $atts
 		)

--- a/widget.subscribe.php
+++ b/widget.subscribe.php
@@ -1,548 +1,548 @@
 <?php
 
 function sailthru_attributes( $attribute_list ) {
-    if ( ! empty( $attribute_list ) ) {
-        $attributes = explode( ',', $attribute_list );
-        $list       = '';
-        foreach ( $attributes as $attribute ) {
-            $split = explode( ':', esc_attr( $attribute ) );
-            $list .= $split[0] . '="' . $split[1] . '" ';
+	if ( ! empty( $attribute_list ) ) {
+		$attributes = explode( ',', $attribute_list );
+		$list	   = '';
+		foreach ( $attributes as $attribute ) {
+			$split = explode( ':', esc_attr( $attribute ) );
+			$list .= $split[0] . '="' . $split[1] . '" ';
 
-        }
-        return $list;
-    }
-    return '';
+		}
+		return $list;
+	}
+	return '';
 }
 
 function sailthru_field_class( $class, $type = '' ) {
-    if ( ! empty( $class ) ) {
-        return 'class="form-control ' . esc_attr( $class ) . '"';
-    }
+	if ( ! empty( $class ) ) {
+		return 'class="form-control ' . esc_attr( $class ) . '"';
+	}
 
-    return '';
+	return '';
 }
 
 function sailthru_field_id( $id ) {
-    if ( ! empty( $id ) ) {
-        return 'id="' . esc_attr( $id ) . '"';
-    }
-    return '';
+	if ( ! empty( $id ) ) {
+		return 'id="' . esc_attr( $id ) . '"';
+	}
+	return '';
 }
 if ( ! defined( 'SAILTHRU_PLUGIN_PATH' ) ) {
-    define( 'SAILTHRU_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
+	define( 'SAILTHRU_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 }
 
 if ( ! defined( 'SAILTHRU_PLUGIN_URL' ) ) {
-    define( 'SAILTHRU_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+	define( 'SAILTHRU_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 }
 
 
 class Sailthru_Subscribe_Widget extends WP_Widget {
 
-    /*--------------------------------------------------*/
-    /* Constructor
-    /*--------------------------------------------------*/
-
-    /**
-     * Instantiates the widget,
-     * loads localization files, and includes necessary stylesheets and JavaScript.
-     */
-    public function __construct() {
-
-        // load plugin text domain
-        add_action( 'init', array( $this, 'load_widget_text_domain' ) );
-
-        parent::__construct(
-            'sailthru-subscribe-id',
-            __( 'Sailthru Subscribe Widget', 'sailthru-for-wordpress' ),
-            array(
-                'classname'   => 'Sailthru_Subscribe',
-                'description' => __( 'A widget to allow your visitors to subscirbe to your Sailthru lists.', 'sailthru-for-wordpress' ),
-            )
-        );
-
-        if ( is_active_widget( false, false, $this->id_base, true ) || shortcode_exists( 'sailthru_widget' ) ) {
-            // Only register widget scripts, styles, and ajax when widget is active
-            // Register admin styles and scripts
-            // According to documentation: admin_print_styles should not be used to enqueue styles or scripts on the admin pages. Use admin_enqueue_scripts instead.
-            add_action( 'admin_enqueue_scripts', array( $this, 'register_admin_scripts' ) );
-
-            // Method to subscribe a user
-            add_action( 'wp_ajax_nopriv_add_subscriber', array( $this, 'add_subscriber' ) );
-            add_action( 'wp_ajax_add_subscriber', array( $this, 'add_subscriber' ) );
-            add_action( 'wp_enqueue_scripts', array( $this, 'register_widget_styles' ) );
-            add_action( 'wp_enqueue_scripts', array( $this, 'register_widget_scripts' ) );
-            add_action( 'wp_head', array( $this, 'add_ajax_library' ) );
-        }
-    } // end constructor
-
-    /*--------------------------------------------------*/
-    /* Widget API Functions
-    /*--------------------------------------------------*/
-
-    /**
-     * Outputs the content of the widget.
-     *
-     * @param array   args  The array of form elements
-     * @param array   instance The current instance of the widget
-     */
-    public function widget( $args, $instance ) {
-
-        if ( empty( $instance['sailthru_list'] ) ) {
-            return false;
-        }
-
-        extract( $args, EXTR_SKIP );
-        if ( isset( $before_widget ) ) {
-            echo wp_kses_post( $before_widget );
-        }
-        include SAILTHRU_PLUGIN_PATH . 'views/widget.subscribe.display.php';
-        if ( isset( $after_widget ) ) {
-            echo wp_kses_post( $after_widget );
-        }
-
-    } // end widget
-
-    /**
-     * Processes the widget's options to be saved.
-     *
-     * @param array   new_instance The previous instance of values before the update.
-     * @param array   old_instance The new instance of values to be generated via the update.
-     */
-    public function update( $new_instance, $old_instance ) {
-
-        $instance = array(
-            'title'         => filter_var( $new_instance['title'], FILTER_SANITIZE_STRING ),
-            'source'        => filter_var( $new_instance['source'], FILTER_SANITIZE_STRING ),
-            'lo_event_name' => filter_var( $new_instance['lo_event_name'], FILTER_SANITIZE_STRING ),
-            'reset_optout_status' => filter_var ( $new_instance[ 'reset_optout_status' ], FILTER_SANITIZE_STRING )
-        );
-
-        $customfields = get_option( 'sailthru_forms_options' );
-        $key          = get_option( 'sailthru_forms_key' );
-
-        for ( $i = 0; $i < $key; $i++ ) {
-            $field_key     = $i + 1;
-            $name_stripped = preg_replace( '/[^\da-z]/i', '_', $customfields[ $field_key ]['sailthru_customfield_name'] );
-            //setup instance variables
-            $instance[ 'show_' . $name_stripped . '_name' ]     = (bool) $new_instance[ 'show_' . $name_stripped . '_name' ];
-            $instance[ 'show_' . $name_stripped . '_required' ] = (bool) $new_instance[ 'show_' . $name_stripped . '_required' ];
-            $instance[ 'show_' . $name_stripped . '_type' ]     = $new_instance[ 'show_' . $name_stripped . '_type' ];
-            $instance['field_order']                            = $new_instance['field_order'];
-            //$instance['sailthru_customfields_order_widget'] = sanitize_text_field($new_instance['field_order']);
-
-        }
-        $instance['sailthru_list'] = is_array( $new_instance['sailthru_list'] ) ? array_map( 'sanitize_text_field', $new_instance['sailthru_list'] ) : '';
-
-        //if ( isset($new_instance['field_order']) && $new_instance['field_order'] != '' ){
-        // update_option( 'sailthru_customfields_order_widget', sanitize_text_field($new_instance['field_order']));
-        //}
-        return $instance;
-
-    } // end widget
-
-    /**
-     * Generates the administration form for the widget.
-     *
-     * @param array   instance The array of keys and values for the widget.
-     */
-    public function form( $instance ) {
-
-        // Default values for a widget instance
-        $instance = wp_parse_args(
-            (array) $instance, array(
-                'title'         => '',
-                'source'        => '',
-                'lo_event_name' => '',
-                'reset_optout_status' => '',
-                'sailthru_list' => array( '' ),
-                'field_order'   => '',
-            )
-        );
-
-        $title         = $instance['title'];
-        $source        = $instance['source'];
-        $lo_event_name = $instance['lo_event_name'];
-        $reset_optout_status = $instance['reset_optout_status'];
-        $sailthru_list = $instance['sailthru_list'];
-        $order         = $field_order = $instance['field_order'];
-        $widget_id     = $this->id;
-
-        // Display the admin form
-        include SAILTHRU_PLUGIN_PATH . 'views/widget.subscribe.admin.php';
-
-    } // end form
-
-    /*--------------------------------------------*
-     * Action Functions
-     *--------------------------------------------*/
-
-
-    /**
-     * If enabled then a user is created in WordPress when a newsletter subscription is processed.
-     * This will only fire when the first_name is present so we can create a username
-     * it's recommended to uses a first and last name
-     */
-    function create_wp_account( $email, $options, $template = '' ) {
-
-        if ( false === apply_filters( 'sailthru_user_registration_enable', true ) ) {
-            return;
-        }
-
-        if ( isset( $options['vars']['first_name'] ) && ! empty( $options['vars']['first_name'] ) ) {
-                 $first_name = $options['vars']['first_name'];
-        } else {
-             $first_name = '';
-        }
-
-        if ( isset( $options['vars']['last_name'] ) && ! empty( $options['vars']['last_name'] ) ) {
-                 $last_name = $options['vars']['last_name'];
-        } else {
-             $last_name = '';
-        }
-
-        $nickname = sanitize_text_field( $first_name . ' ' . $last_name );
-
-        if ( empty( $nickname ) ) {
-            $nickname = $email;
-        }
-
-        $params = array(
-            'options'  => $options,
-            'template' => $template,
-        );
-
-        if ( false === email_exists( $email ) ) {
-            $random_password = wp_generate_password( $length = 12, $include_standard_special_chars = false );
-            $user            = wp_create_user( $email, $random_password, $email );
-            wp_new_user_notification( $user, null, 'user', $params );
-
-            $user_vars             = $options['vars'];
-            $user_vars['ID']       = $user;
-            $user_vars['nickname'] = $first_name . ' ' . $last_name;
-            unset( $user_vars['wp_widget_lists'] );
-            wp_update_user( $user_vars );
-            write_log( 'Account created:' . $email );
-        } else {
-            write_log( 'Account for ' . $email . ' exists' );
-        }
+	/*--------------------------------------------------*/
+	/* Constructor
+	/*--------------------------------------------------*/
+
+	/**
+	 * Instantiates the widget,
+	 * loads localization files, and includes necessary stylesheets and JavaScript.
+	 */
+	public function __construct() {
+
+		// load plugin text domain
+		add_action( 'init', array( $this, 'load_widget_text_domain' ) );
+
+		parent::__construct(
+			'sailthru-subscribe-id',
+			__( 'Sailthru Subscribe Widget', 'sailthru-for-wordpress' ),
+			array(
+				'classname'   => 'Sailthru_Subscribe',
+				'description' => __( 'A widget to allow your visitors to subscirbe to your Sailthru lists.', 'sailthru-for-wordpress' ),
+			)
+		);
+
+		if ( is_active_widget( false, false, $this->id_base, true ) || shortcode_exists( 'sailthru_widget' ) ) {
+			// Only register widget scripts, styles, and ajax when widget is active
+			// Register admin styles and scripts
+			// According to documentation: admin_print_styles should not be used to enqueue styles or scripts on the admin pages. Use admin_enqueue_scripts instead.
+			add_action( 'admin_enqueue_scripts', array( $this, 'register_admin_scripts' ) );
+
+			// Method to subscribe a user
+			add_action( 'wp_ajax_nopriv_add_subscriber', array( $this, 'add_subscriber' ) );
+			add_action( 'wp_ajax_add_subscriber', array( $this, 'add_subscriber' ) );
+			add_action( 'wp_enqueue_scripts', array( $this, 'register_widget_styles' ) );
+			add_action( 'wp_enqueue_scripts', array( $this, 'register_widget_scripts' ) );
+			add_action( 'wp_head', array( $this, 'add_ajax_library' ) );
+		}
+	} // end constructor
+
+	/*--------------------------------------------------*/
+	/* Widget API Functions
+	/*--------------------------------------------------*/
+
+	/**
+	 * Outputs the content of the widget.
+	 *
+	 * @param array   args  The array of form elements
+	 * @param array   instance The current instance of the widget
+	 */
+	public function widget( $args, $instance ) {
+
+		if ( empty( $instance['sailthru_list'] ) ) {
+			return false;
+		}
+
+		extract( $args, EXTR_SKIP );
+		if ( isset( $before_widget ) ) {
+			echo wp_kses_post( $before_widget );
+		}
+		include SAILTHRU_PLUGIN_PATH . 'views/widget.subscribe.display.php';
+		if ( isset( $after_widget ) ) {
+			echo wp_kses_post( $after_widget );
+		}
+
+	} // end widget
+
+	/**
+	 * Processes the widget's options to be saved.
+	 *
+	 * @param array   new_instance The previous instance of values before the update.
+	 * @param array   old_instance The new instance of values to be generated via the update.
+	 */
+	public function update( $new_instance, $old_instance ) {
+
+		$instance = array(
+			'title'		 => filter_var( $new_instance['title'], FILTER_SANITIZE_STRING ),
+			'source'		=> filter_var( $new_instance['source'], FILTER_SANITIZE_STRING ),
+			'lo_event_name' => filter_var( $new_instance['lo_event_name'], FILTER_SANITIZE_STRING ),
+			'reset_optout_status' => filter_var ( $new_instance[ 'reset_optout_status' ], FILTER_SANITIZE_STRING )
+		);
+
+		$customfields = get_option( 'sailthru_forms_options' );
+		$key		  = get_option( 'sailthru_forms_key' );
+
+		for ( $i = 0; $i < $key; $i++ ) {
+			$field_key	 = $i + 1;
+			$name_stripped = preg_replace( '/[^\da-z]/i', '_', $customfields[ $field_key ]['sailthru_customfield_name'] );
+			//setup instance variables
+			$instance[ 'show_' . $name_stripped . '_name' ]	 = (bool) $new_instance[ 'show_' . $name_stripped . '_name' ];
+			$instance[ 'show_' . $name_stripped . '_required' ] = (bool) $new_instance[ 'show_' . $name_stripped . '_required' ];
+			$instance[ 'show_' . $name_stripped . '_type' ]	 = $new_instance[ 'show_' . $name_stripped . '_type' ];
+			$instance['field_order']							= $new_instance['field_order'];
+			//$instance['sailthru_customfields_order_widget'] = sanitize_text_field($new_instance['field_order']);
+
+		}
+		$instance['sailthru_list'] = is_array( $new_instance['sailthru_list'] ) ? array_map( 'sanitize_text_field', $new_instance['sailthru_list'] ) : '';
+
+		//if ( isset($new_instance['field_order']) && $new_instance['field_order'] != '' ){
+		// update_option( 'sailthru_customfields_order_widget', sanitize_text_field($new_instance['field_order']));
+		//}
+		return $instance;
+
+	} // end widget
+
+	/**
+	 * Generates the administration form for the widget.
+	 *
+	 * @param array   instance The array of keys and values for the widget.
+	 */
+	public function form( $instance ) {
+
+		// Default values for a widget instance
+		$instance = wp_parse_args(
+			(array) $instance, array(
+				'title'		 => '',
+				'source'		=> '',
+				'lo_event_name' => '',
+				'reset_optout_status' => '',
+				'sailthru_list' => array( '' ),
+				'field_order'   => '',
+			)
+		);
+
+		$title		 = $instance['title'];
+		$source		= $instance['source'];
+		$lo_event_name = $instance['lo_event_name'];
+		$reset_optout_status = $instance['reset_optout_status'];
+		$sailthru_list = $instance['sailthru_list'];
+		$order		 = $field_order = $instance['field_order'];
+		$widget_id	 = $this->id;
+
+		// Display the admin form
+		include SAILTHRU_PLUGIN_PATH . 'views/widget.subscribe.admin.php';
+
+	} // end form
+
+	/*--------------------------------------------*
+	 * Action Functions
+	 *--------------------------------------------*/
+
+
+	/**
+	 * If enabled then a user is created in WordPress when a newsletter subscription is processed.
+	 * This will only fire when the first_name is present so we can create a username
+	 * it's recommended to uses a first and last name
+	 */
+	function create_wp_account( $email, $options, $template = '' ) {
+
+		if ( false === apply_filters( 'sailthru_user_registration_enable', true ) ) {
+			return;
+		}
+
+		if ( isset( $options['vars']['first_name'] ) && ! empty( $options['vars']['first_name'] ) ) {
+				 $first_name = $options['vars']['first_name'];
+		} else {
+			 $first_name = '';
+		}
+
+		if ( isset( $options['vars']['last_name'] ) && ! empty( $options['vars']['last_name'] ) ) {
+				 $last_name = $options['vars']['last_name'];
+		} else {
+			 $last_name = '';
+		}
+
+		$nickname = sanitize_text_field( $first_name . ' ' . $last_name );
+
+		if ( empty( $nickname ) ) {
+			$nickname = $email;
+		}
+
+		$params = array(
+			'options'  => $options,
+			'template' => $template,
+		);
+
+		if ( false === email_exists( $email ) ) {
+			$random_password = wp_generate_password( $length = 12, $include_standard_special_chars = false );
+			$user			= wp_create_user( $email, $random_password, $email );
+			wp_new_user_notification( $user, null, 'user', $params );
+
+			$user_vars			 = $options['vars'];
+			$user_vars['ID']	   = $user;
+			$user_vars['nickname'] = $first_name . ' ' . $last_name;
+			unset( $user_vars['wp_widget_lists'] );
+			wp_update_user( $user_vars );
+			write_log( 'Account created:' . $email );
+		} else {
+			write_log( 'Account for ' . $email . ' exists' );
+		}
 
-    }
-
-
-
-    /**
-     * Adds the WordPress Ajax Library to the frontend.
-     */
-    public function add_ajax_library() {
-        echo '<script type="text/javascript">';
-        echo 'var sailthru_vars = ' . wp_json_encode( [ 'ajaxurl' => admin_url( 'admin-ajax.php' ) ]);
-        echo '</script>';
-    } // end add_ajax_library
-
-    /*--------------------------------------------------*/
-    /* Public Functions
-    /*--------------------------------------------------*/
+	}
+
+
+
+	/**
+	 * Adds the WordPress Ajax Library to the frontend.
+	 */
+	public function add_ajax_library() {
+		echo '<script type="text/javascript">';
+		echo 'var sailthru_vars = ' . wp_json_encode( [ 'ajaxurl' => admin_url( 'admin-ajax.php' ) ]);
+		echo '</script>';
+	} // end add_ajax_library
+
+	/*--------------------------------------------------*/
+	/* Public Functions
+	/*--------------------------------------------------*/
 
-    /**
-     * Loads the Widget's text domain for localization and translation.
-     */
-    public function load_widget_text_domain() {
-
-        load_plugin_textdomain( 'sailthru-for-wordpress', false, plugin_dir_path( __FILE__ ) . '/lang/' );
-
-    } // end load_widget_text_domain
-
-
-    /**
-     * Registers and enqueues admin-specific JavaScript.
-     */
-    public function register_admin_scripts() {
-
-        wp_enqueue_style( 'sailthru-subscribe-admin-styles', SAILTHRU_PLUGIN_URL . 'css/widget.subscribe.admin.css' );
-
-        wp_enqueue_script( 'jquery' );
-        wp_enqueue_script( 'jquery-ui-sortable' );
-    } // end register_admin_scripts
-
-    /**
-     * Registers and enqueues widget-specific styles.
-     */
-    public function register_widget_styles() {
-
-        wp_enqueue_style( 'sailthru-subscribe-widget-styles', SAILTHRU_PLUGIN_URL . 'css/widget.subscribe.css' );
-
-    } // end register_widget_styles
-
-    /**
-     * Registers and enqueues widget-specific scripts.
-     */
-    public function register_widget_scripts() {
-
-        wp_enqueue_script( 'sailthru-subscribe-script', SAILTHRU_PLUGIN_URL . 'js/widget.subscribe.js', array( 'jquery' ) );
-
-    } // end register_widget_scripts
-
-    /*--------------------------------------------------*/
-    /* Core Functions
-    /*--------------------------------------------------*/
+	/**
+	 * Loads the Widget's text domain for localization and translation.
+	 */
+	public function load_widget_text_domain() {
+
+		load_plugin_textdomain( 'sailthru-for-wordpress', false, plugin_dir_path( __FILE__ ) . '/lang/' );
+
+	} // end load_widget_text_domain
+
+
+	/**
+	 * Registers and enqueues admin-specific JavaScript.
+	 */
+	public function register_admin_scripts() {
+
+		wp_enqueue_style( 'sailthru-subscribe-admin-styles', SAILTHRU_PLUGIN_URL . 'css/widget.subscribe.admin.css' );
+
+		wp_enqueue_script( 'jquery' );
+		wp_enqueue_script( 'jquery-ui-sortable' );
+	} // end register_admin_scripts
+
+	/**
+	 * Registers and enqueues widget-specific styles.
+	 */
+	public function register_widget_styles() {
+
+		wp_enqueue_style( 'sailthru-subscribe-widget-styles', SAILTHRU_PLUGIN_URL . 'css/widget.subscribe.css' );
+
+	} // end register_widget_styles
+
+	/**
+	 * Registers and enqueues widget-specific scripts.
+	 */
+	public function register_widget_scripts() {
+
+		wp_enqueue_script( 'sailthru-subscribe-script', SAILTHRU_PLUGIN_URL . 'js/widget.subscribe.js', array( 'jquery' ) );
+
+	} // end register_widget_scripts
+
+	/*--------------------------------------------------*/
+	/* Core Functions
+	/*--------------------------------------------------*/
 
-    function return_response( $response ) {
-
-        header('Content-Type: application/json');
-        echo  wp_json_encode( $response );
-        exit();
-    }
+	function return_response( $response ) {
+
+		header('Content-Type: application/json');
+		echo  wp_json_encode( $response );
+		exit();
+	}
 
-    function add_subscriber() {
+	function add_subscriber() {
 
-        if ( ! wp_verify_nonce( $_POST['sailthru_nonce'], 'add_subscriber_nonce' ) ) {
-
-            $result = array(
-                'success' => false,
-                'message' => 'This form could not be validated, please refresh the page and try again. ',
-            );
-            $this->return_response( $result );
-        }
-
-        $email = ! empty( $_POST['email'] ) ? sanitize_email( $_POST['email'] ) : false;
+		if ( ! wp_verify_nonce( $_POST['sailthru_nonce'], 'add_subscriber_nonce' ) ) {
+
+			$result = array(
+				'success' => false,
+				'message' => 'This form could not be validated, please refresh the page and try again. ',
+			);
+			$this->return_response( $result );
+		}
+
+		$email = ! empty( $_POST['email'] ) ? sanitize_email( $_POST['email'] ) : false;
 
-        // check if email is valid, if not bail.
-        if ( ! is_email( $email ) ) {
-            $result['success'] = false;
-            $result['message'] = 'Please enter a valid email';
-            $this->return_response( $result );
-        }
+		// check if email is valid, if not bail.
+		if ( ! is_email( $email ) ) {
+			$result['success'] = false;
+			$result['message'] = 'Please enter a valid email';
+			$this->return_response( $result );
+		}
 
-        // check if email address exists in Sailthru.
-        $sailthru   = get_option( 'sailthru_setup_options' );
-        $api_key    = $sailthru['sailthru_api_key'];
-        $api_secret = $sailthru['sailthru_api_secret'];
-
-        $client = new WP_Sailthru_Client( $api_key, $api_secret );
-
-        if ( $client ) {
-
-            $options      = array();
-
-            // set the source
-            if ( isset( $_POST['source'] ) && ! empty( $_POST['source'] ) ) {
-                $source = sanitize_text_field( $_POST['source'] );
-            } else {
-                $source = get_bloginfo( 'url' );
-            }
-
-            // initialize vars with source.
-            $vars         = array( 'source' => $source );
-            $customfields = get_option( 'sailthru_forms_options' );
-            $key          = get_option( 'sailthru_forms_key' );
-
-            for ( $i = 0; $i < $key; $i++ ) {
-                $field_key = $i + 1;
-
-                if ( ! empty( $customfields[ $field_key ]['sailthru_customfield_name'] ) ) {
-                    $name_stripped = preg_replace( '/[^\da-z]/i', '_', $customfields[ $field_key ]['sailthru_customfield_name'] );
-
-                    if ( ! empty( $_POST[ 'custom_' . $name_stripped ] ) ) {
-                        // check to see if this is an array or a string
-                        if ( is_array( $_POST[ 'custom_' . $name_stripped ] ) ) {
-
-                            foreach ( $_POST[ 'custom_' . $name_stripped ] as $val ) {
-                                $var_name             = str_replace( 'custom_', '', $name_stripped );
-                                $vars[ $var_name ] [] = sanitize_text_field( $val );
-                            }
-                        } else {
-                            $var_name          = str_replace( 'custom_', '', $name_stripped );
-                            $vars[ $var_name ] = sanitize_text_field( $_POST[ 'custom_' . $name_stripped ] );
-                        }
-                    }
-                }
-            } //end for loop
-
-
-            $subscribe_to_lists  = array();
-            $sailthru_email_list = sanitize_text_field( $_POST['sailthru_email_list'] );
-            if ( ! empty( $sailthru_email_list ) ) {
-
-                // check for double opt in setting
-                if ( isset( $customfields['sailthru_double_opt_in'] ) && true === $customfields['sailthru_double_opt_in'] ) {
-                    $double_opt_in = true;
-                } else {
-                    $double_opt_in = false;
-                }
-
-                $lists = explode( ',', $sailthru_email_list );
-
-                foreach ( $lists as $key => $list ) {
-                    $subscribe_to_lists[ $list ] = 1;
-                }
-
-                $options['lists'] = $subscribe_to_lists;
-
-            } else {
-
-                $options['lists'] = array( 'Sailthru Subscribe Widget' => 1 ); // subscriber is an orphan
-
-            }
-
-            // clean up vars
-            unset( $vars['email'] );
-            unset( $vars['sailthru_nonce'] );
-            unset( $vars['action'] );
-
-            $options['vars'] = $vars;
-
-            $data = array(
-                'id'     => $email,
-                'fields' => array(
-                    'lists' => 1,
-                    'keys'  => 1,
-                ),
-            );
-
-            $profile = false;
-
-            try {
-                $profile = $client->apiGet( 'user', $data );
-            } catch ( Sailthru_Client_Exception $e ) {
-
-                if ( ! strpos( $e->getMessage(), 'User not found with email' ) ) {
-                    write_log( $e->getMessage() );
-                }
-            }
-
-            $recaptcha_token = sanitize_text_field( $_POST['captcha_token'] );
-
-            if ( ! empty( $sailthru['google_recaptcha_site_key'] ) && ! empty( $sailthru['google_recaptcha_secret'] ) && ! empty( $recaptcha_token ) ) {
-                write_log( "reCaptcha enabled, verifying" );
-                try {
-                    $response = wp_remote_get( 'https://www.google.com/recaptcha/api/siteverify?secret=' . $sailthru['google_recaptcha_secret'] . '&response=' . $recaptcha_token );
-                    $body = wp_remote_retrieve_body( $response );
-                    $data = json_decode( $body, true );
-                    if ( false == $data['success'] ) {
-                        // failed, send an error message here, but keep it vague
-                        $this->return_response(
-                            array(
-                                'success' => false,
-                                'message' => 'Sorry, something went wrong and we could not subscribe you.'
-                            )
-                        );
-                    }
-                } catch ( Exception $e ) {
-                    write_log( $e );
-                }
-            }
-
-            $profile_data = array(
-                'id' => $email,
-                'key' => 'email',
-                'vars' => $options['vars'],
-                'lists' => $options['lists'],
-            );
-
-            $should_update_optout = isset( $_POST['reset_optout_status'] ) && ! empty( $_POST['reset_optout_status'] ) ? 'none': '';
-            if ($should_update_optout) {
-                $profile_data['optout_email'] = 'none';
-            }
-
-            if ( ! empty( $profile ) ) {
-
-                if ( isset( $profile['lists'] ) && count( $profile['lists'] ) > 0 ) {
-
-                    // now we need to check which lists they are being subscribed to which they are not a member of.
-                    foreach ( $options['lists'] as $list_name => $list_val ) {
-
-                        if ( ! array_key_exists( $list_name, $profile['lists'] ) ) {
-                            $new_lists[] = $list_name;
-                        }
-                    }
-                } else {
-                    // all of the lists are new lists
-                    $new_lists = $options['lists'];
-                }
-
-                try {
-                    $client->apiPost( 'user', $profile_data );
-                    $new_lists = $options['lists'];
-
-                } catch ( Sailthru_Client_Exception $e ) {
-                    write_log( $e );
-                }
-
-            } else {
-
-                try {
-                    $client->apiPost( 'user', $profile_data );
-                    $new_lists = $options['lists'];
-
-                } catch ( Sailthru_Client_Exception $e ) {
-                    write_log( $e );
-                }
-            }
-
-            // check if the user is a new subscriber to any lists.
-            $new_subscriber = count( $new_lists ) > 0 ? true : false;
-
-            if ( isset( $customfields['sailthru_welcome_template'] ) && ! empty( $customfields['sailthru_welcome_template'] ) ) {
-
-                if ( $new_subscriber ) {
-
-                    try {
-                        $client->send( $customfields['sailthru_welcome_template'], $email, $vars );
-                    } catch ( Sailthru_Client_Exception $e ) {
-                        write_log( $e );
-                    }
-                }
-            }
-
-            // Handle the Event If it's been set to fire.
-            if ( isset( $_POST['lo_event_name'] ) && ! empty( $_POST['lo_event_name'] ) ) {
-                $event = sanitize_text_field( $_POST['lo_event_name'] );
-            } else {
-                $event = false;
-            }
-
-            if ( $event ) {
-
-                $event_data = array(
-                    'id'    => $email,
-                    'event' => $event,
-                    'vars'  => $options['vars'],
-                );
-
-                try {
-                    $client->apiPost( 'event', $event_data );
-                } catch ( Sailthru_Client_Exception $e ) {
-                    write_log( $e );
-                }
-            }
-
-            if ( has_filter( 'sailthru_user_registration_enable' ) ) {
-                $setup    = get_option( 'sailthru_setup_options' );
-                $template = '';
-                if ( isset( $setup['sailthru_setup_new_user_override_template'] ) && ! empty( $setup['sailthru_setup_new_user_override_template'] ) ) {
-                    $template = $setup['sailthru_setup_new_user_override_template'];
-                }
-                $this->create_wp_account( $email, $options, $template );
-            }
-
-            // format response.
-            $result = array(
-                'success' => true,
-                'message' => 'User Subscribed',
-            );
-
-            $this->return_response( $result );
-
-        } else {
-
-            // format response.
-            $result['success'] = false;
-            $result['message'] = 'Sorry, something went wrong and we could not subscribe you.';
-            $this->return_response( $result );
-        }
-
-    }
+		// check if email address exists in Sailthru.
+		$sailthru   = get_option( 'sailthru_setup_options' );
+		$api_key	= $sailthru['sailthru_api_key'];
+		$api_secret = $sailthru['sailthru_api_secret'];
+
+		$client = new WP_Sailthru_Client( $api_key, $api_secret );
+
+		if ( $client ) {
+
+			$options	  = array();
+
+			// set the source
+			if ( isset( $_POST['source'] ) && ! empty( $_POST['source'] ) ) {
+				$source = sanitize_text_field( $_POST['source'] );
+			} else {
+				$source = get_bloginfo( 'url' );
+			}
+
+			// initialize vars with source.
+			$vars		 = array( 'source' => $source );
+			$customfields = get_option( 'sailthru_forms_options' );
+			$key		  = get_option( 'sailthru_forms_key' );
+
+			for ( $i = 0; $i < $key; $i++ ) {
+				$field_key = $i + 1;
+
+				if ( ! empty( $customfields[ $field_key ]['sailthru_customfield_name'] ) ) {
+					$name_stripped = preg_replace( '/[^\da-z]/i', '_', $customfields[ $field_key ]['sailthru_customfield_name'] );
+
+					if ( ! empty( $_POST[ 'custom_' . $name_stripped ] ) ) {
+						// check to see if this is an array or a string
+						if ( is_array( $_POST[ 'custom_' . $name_stripped ] ) ) {
+
+							foreach ( $_POST[ 'custom_' . $name_stripped ] as $val ) {
+								$var_name			 = str_replace( 'custom_', '', $name_stripped );
+								$vars[ $var_name ] [] = sanitize_text_field( $val );
+							}
+						} else {
+							$var_name		  = str_replace( 'custom_', '', $name_stripped );
+							$vars[ $var_name ] = sanitize_text_field( $_POST[ 'custom_' . $name_stripped ] );
+						}
+					}
+				}
+			} //end for loop
+
+
+			$subscribe_to_lists  = array();
+			$sailthru_email_list = sanitize_text_field( $_POST['sailthru_email_list'] );
+			if ( ! empty( $sailthru_email_list ) ) {
+
+				// check for double opt in setting
+				if ( isset( $customfields['sailthru_double_opt_in'] ) && true === $customfields['sailthru_double_opt_in'] ) {
+					$double_opt_in = true;
+				} else {
+					$double_opt_in = false;
+				}
+
+				$lists = explode( ',', $sailthru_email_list );
+
+				foreach ( $lists as $key => $list ) {
+					$subscribe_to_lists[ $list ] = 1;
+				}
+
+				$options['lists'] = $subscribe_to_lists;
+
+			} else {
+
+				$options['lists'] = array( 'Sailthru Subscribe Widget' => 1 ); // subscriber is an orphan
+
+			}
+
+			// clean up vars
+			unset( $vars['email'] );
+			unset( $vars['sailthru_nonce'] );
+			unset( $vars['action'] );
+
+			$options['vars'] = $vars;
+
+			$data = array(
+				'id'	 => $email,
+				'fields' => array(
+					'lists' => 1,
+					'keys'  => 1,
+				),
+			);
+
+			$profile = false;
+
+			try {
+				$profile = $client->apiGet( 'user', $data );
+			} catch ( Sailthru_Client_Exception $e ) {
+
+				if ( ! strpos( $e->getMessage(), 'User not found with email' ) ) {
+					write_log( $e->getMessage() );
+				}
+			}
+
+			$recaptcha_token = sanitize_text_field( $_POST['captcha_token'] );
+
+			if ( ! empty( $sailthru['google_recaptcha_site_key'] ) && ! empty( $sailthru['google_recaptcha_secret'] ) && ! empty( $recaptcha_token ) ) {
+				write_log( "reCaptcha enabled, verifying" );
+				try {
+					$response = wp_remote_get( 'https://www.google.com/recaptcha/api/siteverify?secret=' . $sailthru['google_recaptcha_secret'] . '&response=' . $recaptcha_token );
+					$body = wp_remote_retrieve_body( $response );
+					$data = json_decode( $body, true );
+					if ( false == $data['success'] ) {
+						// failed, send an error message here, but keep it vague
+						$this->return_response(
+							array(
+								'success' => false,
+								'message' => 'Sorry, something went wrong and we could not subscribe you.'
+							)
+						);
+					}
+				} catch ( Exception $e ) {
+					write_log( $e );
+				}
+			}
+
+			$profile_data = array(
+				'id' => $email,
+				'key' => 'email',
+				'vars' => $options['vars'],
+				'lists' => $options['lists'],
+			);
+
+			$should_update_optout = isset( $_POST['reset_optout_status'] ) && ! empty( $_POST['reset_optout_status'] ) ? 'none': '';
+			if ($should_update_optout) {
+				$profile_data['optout_email'] = 'none';
+			}
+
+			if ( ! empty( $profile ) ) {
+
+				if ( isset( $profile['lists'] ) && count( $profile['lists'] ) > 0 ) {
+
+					// now we need to check which lists they are being subscribed to which they are not a member of.
+					foreach ( $options['lists'] as $list_name => $list_val ) {
+
+						if ( ! array_key_exists( $list_name, $profile['lists'] ) ) {
+							$new_lists[] = $list_name;
+						}
+					}
+				} else {
+					// all of the lists are new lists
+					$new_lists = $options['lists'];
+				}
+
+				try {
+					$client->apiPost( 'user', $profile_data );
+					$new_lists = $options['lists'];
+
+				} catch ( Sailthru_Client_Exception $e ) {
+					write_log( $e );
+				}
+
+			} else {
+
+				try {
+					$client->apiPost( 'user', $profile_data );
+					$new_lists = $options['lists'];
+
+				} catch ( Sailthru_Client_Exception $e ) {
+					write_log( $e );
+				}
+			}
+
+			// check if the user is a new subscriber to any lists.
+			$new_subscriber = count( $new_lists ) > 0 ? true : false;
+
+			if ( isset( $customfields['sailthru_welcome_template'] ) && ! empty( $customfields['sailthru_welcome_template'] ) ) {
+
+				if ( $new_subscriber ) {
+
+					try {
+						$client->send( $customfields['sailthru_welcome_template'], $email, $vars );
+					} catch ( Sailthru_Client_Exception $e ) {
+						write_log( $e );
+					}
+				}
+			}
+
+			// Handle the Event If it's been set to fire.
+			if ( isset( $_POST['lo_event_name'] ) && ! empty( $_POST['lo_event_name'] ) ) {
+				$event = sanitize_text_field( $_POST['lo_event_name'] );
+			} else {
+				$event = false;
+			}
+
+			if ( $event ) {
+
+				$event_data = array(
+					'id'	=> $email,
+					'event' => $event,
+					'vars'  => $options['vars'],
+				);
+
+				try {
+					$client->apiPost( 'event', $event_data );
+				} catch ( Sailthru_Client_Exception $e ) {
+					write_log( $e );
+				}
+			}
+
+			if ( has_filter( 'sailthru_user_registration_enable' ) ) {
+				$setup	= get_option( 'sailthru_setup_options' );
+				$template = '';
+				if ( isset( $setup['sailthru_setup_new_user_override_template'] ) && ! empty( $setup['sailthru_setup_new_user_override_template'] ) ) {
+					$template = $setup['sailthru_setup_new_user_override_template'];
+				}
+				$this->create_wp_account( $email, $options, $template );
+			}
+
+			// format response.
+			$result = array(
+				'success' => true,
+				'message' => 'User Subscribed',
+			);
+
+			$this->return_response( $result );
+
+		} else {
+
+			// format response.
+			$result['success'] = false;
+			$result['message'] = 'Sorry, something went wrong and we could not subscribe you.';
+			$this->return_response( $result );
+		}
+
+	}
 
 
 
@@ -556,63 +556,63 @@ register_activation_hook( __FILE__, array( 'Sailthru_Subscribe', 'activate' ) );
  * Register Sailthru Subscribe Widget
  */
 function sailthru_register_subscribe_widget() {
-    register_widget( 'Sailthru_Subscribe_Widget' );
+	register_widget( 'Sailthru_Subscribe_Widget' );
 }
 add_action( 'widgets_init', 'sailthru_register_subscribe_widget' );
 
 function sailthru_widget_shortcode( $atts ) {
 
-    // Configure defaults and extract the attributes into variables
-    extract(
-        shortcode_atts(
-            array(
-                'fields'          => 'name',
-                'modal'           => 'false',
-                'text'            => 'Subscribe',
-                'sailthru_list'   => array(),
-                'field_order'     => '',
-                'using_shortcode' => true,
-            ), $atts
-        )
-    );
+	// Configure defaults and extract the attributes into variables
+	extract(
+		shortcode_atts(
+			array(
+				'fields'		  => 'name',
+				'modal'		   => 'false',
+				'text'			=> 'Subscribe',
+				'sailthru_list'   => array(),
+				'field_order'	 => '',
+				'using_shortcode' => true,
+			), $atts
+		)
+	);
 
-    if ( empty( $atts['using_shortcode'] ) ) {
-        $atts['using_shortcode'] = true;
-    }
+	if ( empty( $atts['using_shortcode'] ) ) {
+		$atts['using_shortcode'] = true;
+	}
 
-    if ( empty( $atts['text'] ) ) {
-        $atts['text'] = 'Subscribe to our newsletter';
-    }
+	if ( empty( $atts['text'] ) ) {
+		$atts['text'] = 'Subscribe to our newsletter';
+	}
 
-    // the widget doesn't render if there is no email list specified.
-    if ( empty( $atts['sailthru_list'] ) ) {
-        $atts['sailthru_list'] = array( 'Sailthru Wordpress Shortcode' );
-    }
+	// the widget doesn't render if there is no email list specified.
+	if ( empty( $atts['sailthru_list'] ) ) {
+		$atts['sailthru_list'] = array( 'Sailthru Wordpress Shortcode' );
+	}
 
-    if ( ! empty( $atts['modal'] ) ) {
+	if ( ! empty( $atts['modal'] ) ) {
 
-        if ( 'true' === $atts['modal'] ) {
-            $before_widget = '<div id="mask"></div><a class="show_shortcode" href="#">' . esc_html( $atts['text'] ) . '</a><div id="sailthru-modal"><div class="sailthru_shortcode_hidden">';
-            $after_widget  = '</div></div>';
-        } else {
-            $before_widget = '<div class="sailthru_shortcode">';
-            $after_widget  = '</div>';
-        }
-    } else {
-        $before_widget = '<div class="sailthru_shortcode">';
-        $after_widget  = '</div>';
-    }
+		if ( 'true' === $atts['modal'] ) {
+			$before_widget = '<div id="mask"></div><a class="show_shortcode" href="#">' . esc_html( $atts['text'] ) . '</a><div id="sailthru-modal"><div class="sailthru_shortcode_hidden">';
+			$after_widget  = '</div></div>';
+		} else {
+			$before_widget = '<div class="sailthru_shortcode">';
+			$after_widget  = '</div>';
+		}
+	} else {
+		$before_widget = '<div class="sailthru_shortcode">';
+		$after_widget  = '</div>';
+	}
 
-    $args = array(
-        'before_widget' => $before_widget,
-        'after_widget'  => '</div>',
-        'before_title'  => '<div class="widget-title">',
-        'after_title'   => $after_widget,
-    );
+	$args = array(
+		'before_widget' => $before_widget,
+		'after_widget'  => '</div>',
+		'before_title'  => '<div class="widget-title">',
+		'after_title'   => $after_widget,
+	);
 
-    ob_start();
-    the_widget( 'Sailthru_Subscribe_Widget', $atts, $args );
-    $output = ob_get_clean();
-    return $output;
+	ob_start();
+	the_widget( 'Sailthru_Subscribe_Widget', $atts, $args );
+	$output = ob_get_clean();
+	return $output;
 }
 add_shortcode( 'sailthru_widget', 'sailthru_widget_shortcode' );

--- a/widget.subscribe.php
+++ b/widget.subscribe.php
@@ -414,7 +414,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 				}
 			}
 
-			if ( isset( $sailthru['google_recaptcha_site_key'], $sailthru['google_recaptcha_secret'] ) && isset ( $_POST['captcha_token'] ) && ! empty( $_POST['captcha_token'] ) ) {
+			if ( ! empty( $sailthru['google_recaptcha_site_key'] ) && ! empty( $sailthru['google_recaptcha_secret'] ) && isset ( $_POST['captcha_token'] ) && ! empty( $_POST['captcha_token'] ) ) {
 				write_log( "reCaptcha enabled, verifying" );
 				try {
 					$response = wp_remote_get( 'https://www.google.com/recaptcha/api/siteverify?secret=' . $sailthru['google_recaptcha_secret'] . '&response=' . $_POST['captcha_token'] );

--- a/widget.subscribe.php
+++ b/widget.subscribe.php
@@ -62,22 +62,20 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 		);
 
 		// Only register widget scripts, styles, and ajax when widget is active
-		if ( is_active_widget( false, false, $this->id_base, true ) ) {
 			// Register admin styles and scripts
 			// According to documentation: admin_print_styles should not be used to enqueue styles or scripts on the admin pages. Use admin_enqueue_scripts instead.
-			add_action( 'admin_enqueue_scripts', array( $this, 'register_admin_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'register_admin_scripts' ) );
 
 			// Register site styles and scripts
-			add_action( 'wp_enqueue_scripts', array( $this, 'register_widget_styles' ) );
-			add_action( 'wp_enqueue_scripts', array( $this, 'register_widget_scripts' ) );
 
 			// Include the Ajax library on the front end
-			add_action( 'wp_head', array( $this, 'add_ajax_library' ) );
 
 			// Method to subscribe a user
-			add_action( 'wp_ajax_nopriv_add_subscriber', array( $this, 'add_subscriber' ) );
-			add_action( 'wp_ajax_add_subscriber', array( $this, 'add_subscriber' ) );
-		}
+		add_action( 'wp_ajax_nopriv_add_subscriber', array( $this, 'add_subscriber' ) );
+		add_action( 'wp_ajax_add_subscriber', array( $this, 'add_subscriber' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'register_widget_styles' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'register_widget_scripts' ) );
+		add_action( 'wp_head', array( $this, 'add_ajax_library' ) );
 
 	} // end constructor
 
@@ -120,6 +118,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 			'title'         => filter_var( $new_instance['title'], FILTER_SANITIZE_STRING ),
 			'source'        => filter_var( $new_instance['source'], FILTER_SANITIZE_STRING ),
 			'lo_event_name' => filter_var( $new_instance['lo_event_name'], FILTER_SANITIZE_STRING ),
+			'reset_optout_status' => filter_var ( $new_instance[ 'reset_optout_status' ], FILTER_SANITIZE_STRING )
 		);
 
 		$customfields = get_option( 'sailthru_forms_options' );
@@ -158,6 +157,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 				'title'         => '',
 				'source'        => '',
 				'lo_event_name' => '',
+				'reset_optout_status' => '',
 				'sailthru_list' => array( '' ),
 				'field_order'   => '',
 			)
@@ -166,6 +166,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 		$title         = $instance['title'];
 		$source        = $instance['source'];
 		$lo_event_name = $instance['lo_event_name'];
+		$reset_optout_status = $instance['reset_optout_status'];
 		$sailthru_list = $instance['sailthru_list'];
 		$order         = $field_order = $instance['field_order'];
 		$widget_id     = $this->id;
@@ -413,6 +414,32 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 				}
 			}
 
+			if ( isset( $sailthru['google_recaptcha_site_key'], $sailthru['google_recaptcha_secret'] ) && isset ( $_POST['captcha_token'] ) && ! empty( $_POST['captcha_token'] ) ) {
+				write_log( "reCaptcha enabled, verifying" );
+				try {
+					$response = wp_remote_get( 'https://www.google.com/recaptcha/api/siteverify?secret=' . $sailthru['google_recaptcha_secret'] . '&response=' . $_POST['captcha_token'] );
+					if ( false == $response['body']['success'] ) {
+						throw new Exception( 'User failed reCaptcha test' );
+					}
+				} catch (Exception $e) {
+					write_log( $e->getMessage() );
+				}
+			}
+
+			if ( isset( $_POST['reset_optout_status'] ) && ! empty( $_POST['reset_optout_status'] ) ) {
+				$reset_optout_status = 'none';
+			} else {
+				$reset_optout_status = '';
+			}
+
+			$profile_data = array(
+				'id'    => $email,
+				'key'   => 'email',
+				'vars'  => $options['vars'],
+				'lists' => $options['lists'],
+				'optout_email' => $reset_optout_status
+			);
+
 			if ( ! empty( $profile ) ) {
 
 				if ( isset( $profile['lists'] ) && count( $profile['lists'] ) > 0 ) {
@@ -430,12 +457,6 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 				}
 
 				try {
-					$profile_data = array(
-						'id'    => $email,
-						'key'   => 'email',
-						'vars'  => $options['vars'],
-						'lists' => $options['lists'],
-					);
 					$client->apiPost( 'user', $profile_data );
 					$new_lists = $options['lists'];
 
@@ -446,12 +467,6 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 			} else {
 
 				try {
-					$profile_data = array(
-						'id'    => $email,
-						'key'   => 'email',
-						'vars'  => $options['vars'],
-						'lists' => $options['lists'],
-					);
 					$client->apiPost( 'user', $profile_data );
 					$new_lists = $options['lists'];
 

--- a/widget.subscribe.php
+++ b/widget.subscribe.php
@@ -1,546 +1,548 @@
 <?php
 
 function sailthru_attributes( $attribute_list ) {
-	if ( ! empty( $attribute_list ) ) {
-		$attributes = explode( ',', $attribute_list );
-		$list       = '';
-		foreach ( $attributes as $attribute ) {
-			$split = explode( ':', esc_attr( $attribute ) );
-			$list .= $split[0] . '="' . $split[1] . '" ';
+    if ( ! empty( $attribute_list ) ) {
+        $attributes = explode( ',', $attribute_list );
+        $list       = '';
+        foreach ( $attributes as $attribute ) {
+            $split = explode( ':', esc_attr( $attribute ) );
+            $list .= $split[0] . '="' . $split[1] . '" ';
 
-		}
-		return $list;
-	}
-	return '';
+        }
+        return $list;
+    }
+    return '';
 }
 
 function sailthru_field_class( $class, $type = '' ) {
-	if ( ! empty( $class ) ) {
-		return 'class="form-control ' . esc_attr( $class ) . '"';
-	}
+    if ( ! empty( $class ) ) {
+        return 'class="form-control ' . esc_attr( $class ) . '"';
+    }
 
-	return '';
+    return '';
 }
 
 function sailthru_field_id( $id ) {
-	if ( ! empty( $id ) ) {
-		return 'id="' . esc_attr( $id ) . '"';
-	}
-	return '';
+    if ( ! empty( $id ) ) {
+        return 'id="' . esc_attr( $id ) . '"';
+    }
+    return '';
 }
 if ( ! defined( 'SAILTHRU_PLUGIN_PATH' ) ) {
-	define( 'SAILTHRU_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
+    define( 'SAILTHRU_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 }
 
 if ( ! defined( 'SAILTHRU_PLUGIN_URL' ) ) {
-	define( 'SAILTHRU_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+    define( 'SAILTHRU_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 }
 
 
 class Sailthru_Subscribe_Widget extends WP_Widget {
 
-	/*--------------------------------------------------*/
-	/* Constructor
-	/*--------------------------------------------------*/
-
-	/**
-	 * Instantiates the widget,
-	 * loads localization files, and includes necessary stylesheets and JavaScript.
-	 */
-	public function __construct() {
-
-		// load plugin text domain
-		add_action( 'init', array( $this, 'load_widget_text_domain' ) );
-
-		parent::__construct(
-			'sailthru-subscribe-id',
-			__( 'Sailthru Subscribe Widget', 'sailthru-for-wordpress' ),
-			array(
-				'classname'   => 'Sailthru_Subscribe',
-				'description' => __( 'A widget to allow your visitors to subscirbe to your Sailthru lists.', 'sailthru-for-wordpress' ),
-			)
-		);
-
-		if ( is_active_widget( false, false, $this->id_base, true ) || shortcode_exists( 'sailthru_widget' ) ) {
-			// Only register widget scripts, styles, and ajax when widget is active
-			// Register admin styles and scripts
-			// According to documentation: admin_print_styles should not be used to enqueue styles or scripts on the admin pages. Use admin_enqueue_scripts instead.
-			add_action( 'admin_enqueue_scripts', array( $this, 'register_admin_scripts' ) );
-
-			// Method to subscribe a user
-			add_action( 'wp_ajax_nopriv_add_subscriber', array( $this, 'add_subscriber' ) );
-			add_action( 'wp_ajax_add_subscriber', array( $this, 'add_subscriber' ) );
-			add_action( 'wp_enqueue_scripts', array( $this, 'register_widget_styles' ) );
-			add_action( 'wp_enqueue_scripts', array( $this, 'register_widget_scripts' ) );
-			add_action( 'wp_head', array( $this, 'add_ajax_library' ) );
-		}
-	} // end constructor
-
-	/*--------------------------------------------------*/
-	/* Widget API Functions
-	/*--------------------------------------------------*/
-
-	/**
-	 * Outputs the content of the widget.
-	 *
-	 * @param array   args  The array of form elements
-	 * @param array   instance The current instance of the widget
-	 */
-	public function widget( $args, $instance ) {
-
-		if ( empty( $instance['sailthru_list'] ) ) {
-			return false;
-		}
-
-		extract( $args, EXTR_SKIP );
-		if ( isset( $before_widget ) ) {
-			echo wp_kses_post( $before_widget );
-		}
-		include SAILTHRU_PLUGIN_PATH . 'views/widget.subscribe.display.php';
-		if ( isset( $after_widget ) ) {
-			echo wp_kses_post( $after_widget );
-		}
-
-	} // end widget
-
-	/**
-	 * Processes the widget's options to be saved.
-	 *
-	 * @param array   new_instance The previous instance of values before the update.
-	 * @param array   old_instance The new instance of values to be generated via the update.
-	 */
-	public function update( $new_instance, $old_instance ) {
-
-		$instance = array(
-			'title'         => filter_var( $new_instance['title'], FILTER_SANITIZE_STRING ),
-			'source'        => filter_var( $new_instance['source'], FILTER_SANITIZE_STRING ),
-			'lo_event_name' => filter_var( $new_instance['lo_event_name'], FILTER_SANITIZE_STRING ),
-			'reset_optout_status' => filter_var ( $new_instance[ 'reset_optout_status' ], FILTER_SANITIZE_STRING )
-		);
-
-		$customfields = get_option( 'sailthru_forms_options' );
-		$key          = get_option( 'sailthru_forms_key' );
-
-		for ( $i = 0; $i < $key; $i++ ) {
-			$field_key     = $i + 1;
-			$name_stripped = preg_replace( '/[^\da-z]/i', '_', $customfields[ $field_key ]['sailthru_customfield_name'] );
-			//setup instance variables
-			$instance[ 'show_' . $name_stripped . '_name' ]     = (bool) $new_instance[ 'show_' . $name_stripped . '_name' ];
-			$instance[ 'show_' . $name_stripped . '_required' ] = (bool) $new_instance[ 'show_' . $name_stripped . '_required' ];
-			$instance[ 'show_' . $name_stripped . '_type' ]     = $new_instance[ 'show_' . $name_stripped . '_type' ];
-			$instance['field_order']                            = $new_instance['field_order'];
-			//$instance['sailthru_customfields_order_widget'] = sanitize_text_field($new_instance['field_order']);
-
-		}
-		$instance['sailthru_list'] = is_array( $new_instance['sailthru_list'] ) ? array_map( 'sanitize_text_field', $new_instance['sailthru_list'] ) : '';
-
-		//if ( isset($new_instance['field_order']) && $new_instance['field_order'] != '' ){
-		// update_option( 'sailthru_customfields_order_widget', sanitize_text_field($new_instance['field_order']));
-		//}
-		return $instance;
-
-	} // end widget
-
-	/**
-	 * Generates the administration form for the widget.
-	 *
-	 * @param array   instance The array of keys and values for the widget.
-	 */
-	public function form( $instance ) {
-
-		// Default values for a widget instance
-		$instance = wp_parse_args(
-			(array) $instance, array(
-				'title'         => '',
-				'source'        => '',
-				'lo_event_name' => '',
-				'reset_optout_status' => '',
-				'sailthru_list' => array( '' ),
-				'field_order'   => '',
-			)
-		);
-
-		$title         = $instance['title'];
-		$source        = $instance['source'];
-		$lo_event_name = $instance['lo_event_name'];
-		$reset_optout_status = $instance['reset_optout_status'];
-		$sailthru_list = $instance['sailthru_list'];
-		$order         = $field_order = $instance['field_order'];
-		$widget_id     = $this->id;
-
-		// Display the admin form
-		include SAILTHRU_PLUGIN_PATH . 'views/widget.subscribe.admin.php';
-
-	} // end form
-
-	/*--------------------------------------------*
-	 * Action Functions
-	 *--------------------------------------------*/
-
-
-	/**
-	 * If enabled then a user is created in WordPress when a newsletter subscription is processed.
-	 * This will only fire when the first_name is present so we can create a username
-	 * it's recommended to uses a first and last name
-	 */
-	function create_wp_account( $email, $options, $template = '' ) {
-
-		if ( false === apply_filters( 'sailthru_user_registration_enable', true ) ) {
-			return;
-		}
-
-		if ( isset( $options['vars']['first_name'] ) && ! empty( $options['vars']['first_name'] ) ) {
-				 $first_name = $options['vars']['first_name'];
-		} else {
-			 $first_name = '';
-		}
-
-		if ( isset( $options['vars']['last_name'] ) && ! empty( $options['vars']['last_name'] ) ) {
-				 $last_name = $options['vars']['last_name'];
-		} else {
-			 $last_name = '';
-		}
-
-		$nickname = sanitize_text_field( $first_name . ' ' . $last_name );
-
-		if ( empty( $nickname ) ) {
-			$nickname = $email;
-		}
-
-		$params = array(
-			'options'  => $options,
-			'template' => $template,
-		);
-
-		if ( false === email_exists( $email ) ) {
-			$random_password = wp_generate_password( $length = 12, $include_standard_special_chars = false );
-			$user            = wp_create_user( $email, $random_password, $email );
-			wp_new_user_notification( $user, null, 'user', $params );
-
-			$user_vars             = $options['vars'];
-			$user_vars['ID']       = $user;
-			$user_vars['nickname'] = $first_name . ' ' . $last_name;
-			unset( $user_vars['wp_widget_lists'] );
-			wp_update_user( $user_vars );
-			write_log( 'Account created:' . $email );
-		} else {
-			write_log( 'Account for ' . $email . ' exists' );
-		}
+    /*--------------------------------------------------*/
+    /* Constructor
+    /*--------------------------------------------------*/
+
+    /**
+     * Instantiates the widget,
+     * loads localization files, and includes necessary stylesheets and JavaScript.
+     */
+    public function __construct() {
+
+        // load plugin text domain
+        add_action( 'init', array( $this, 'load_widget_text_domain' ) );
+
+        parent::__construct(
+            'sailthru-subscribe-id',
+            __( 'Sailthru Subscribe Widget', 'sailthru-for-wordpress' ),
+            array(
+                'classname'   => 'Sailthru_Subscribe',
+                'description' => __( 'A widget to allow your visitors to subscirbe to your Sailthru lists.', 'sailthru-for-wordpress' ),
+            )
+        );
+
+        if ( is_active_widget( false, false, $this->id_base, true ) || shortcode_exists( 'sailthru_widget' ) ) {
+            // Only register widget scripts, styles, and ajax when widget is active
+            // Register admin styles and scripts
+            // According to documentation: admin_print_styles should not be used to enqueue styles or scripts on the admin pages. Use admin_enqueue_scripts instead.
+            add_action( 'admin_enqueue_scripts', array( $this, 'register_admin_scripts' ) );
+
+            // Method to subscribe a user
+            add_action( 'wp_ajax_nopriv_add_subscriber', array( $this, 'add_subscriber' ) );
+            add_action( 'wp_ajax_add_subscriber', array( $this, 'add_subscriber' ) );
+            add_action( 'wp_enqueue_scripts', array( $this, 'register_widget_styles' ) );
+            add_action( 'wp_enqueue_scripts', array( $this, 'register_widget_scripts' ) );
+            add_action( 'wp_head', array( $this, 'add_ajax_library' ) );
+        }
+    } // end constructor
+
+    /*--------------------------------------------------*/
+    /* Widget API Functions
+    /*--------------------------------------------------*/
+
+    /**
+     * Outputs the content of the widget.
+     *
+     * @param array   args  The array of form elements
+     * @param array   instance The current instance of the widget
+     */
+    public function widget( $args, $instance ) {
+
+        if ( empty( $instance['sailthru_list'] ) ) {
+            return false;
+        }
+
+        extract( $args, EXTR_SKIP );
+        if ( isset( $before_widget ) ) {
+            echo wp_kses_post( $before_widget );
+        }
+        include SAILTHRU_PLUGIN_PATH . 'views/widget.subscribe.display.php';
+        if ( isset( $after_widget ) ) {
+            echo wp_kses_post( $after_widget );
+        }
+
+    } // end widget
+
+    /**
+     * Processes the widget's options to be saved.
+     *
+     * @param array   new_instance The previous instance of values before the update.
+     * @param array   old_instance The new instance of values to be generated via the update.
+     */
+    public function update( $new_instance, $old_instance ) {
+
+        $instance = array(
+            'title'         => filter_var( $new_instance['title'], FILTER_SANITIZE_STRING ),
+            'source'        => filter_var( $new_instance['source'], FILTER_SANITIZE_STRING ),
+            'lo_event_name' => filter_var( $new_instance['lo_event_name'], FILTER_SANITIZE_STRING ),
+            'reset_optout_status' => filter_var ( $new_instance[ 'reset_optout_status' ], FILTER_SANITIZE_STRING )
+        );
+
+        $customfields = get_option( 'sailthru_forms_options' );
+        $key          = get_option( 'sailthru_forms_key' );
+
+        for ( $i = 0; $i < $key; $i++ ) {
+            $field_key     = $i + 1;
+            $name_stripped = preg_replace( '/[^\da-z]/i', '_', $customfields[ $field_key ]['sailthru_customfield_name'] );
+            //setup instance variables
+            $instance[ 'show_' . $name_stripped . '_name' ]     = (bool) $new_instance[ 'show_' . $name_stripped . '_name' ];
+            $instance[ 'show_' . $name_stripped . '_required' ] = (bool) $new_instance[ 'show_' . $name_stripped . '_required' ];
+            $instance[ 'show_' . $name_stripped . '_type' ]     = $new_instance[ 'show_' . $name_stripped . '_type' ];
+            $instance['field_order']                            = $new_instance['field_order'];
+            //$instance['sailthru_customfields_order_widget'] = sanitize_text_field($new_instance['field_order']);
+
+        }
+        $instance['sailthru_list'] = is_array( $new_instance['sailthru_list'] ) ? array_map( 'sanitize_text_field', $new_instance['sailthru_list'] ) : '';
+
+        //if ( isset($new_instance['field_order']) && $new_instance['field_order'] != '' ){
+        // update_option( 'sailthru_customfields_order_widget', sanitize_text_field($new_instance['field_order']));
+        //}
+        return $instance;
+
+    } // end widget
+
+    /**
+     * Generates the administration form for the widget.
+     *
+     * @param array   instance The array of keys and values for the widget.
+     */
+    public function form( $instance ) {
+
+        // Default values for a widget instance
+        $instance = wp_parse_args(
+            (array) $instance, array(
+                'title'         => '',
+                'source'        => '',
+                'lo_event_name' => '',
+                'reset_optout_status' => '',
+                'sailthru_list' => array( '' ),
+                'field_order'   => '',
+            )
+        );
+
+        $title         = $instance['title'];
+        $source        = $instance['source'];
+        $lo_event_name = $instance['lo_event_name'];
+        $reset_optout_status = $instance['reset_optout_status'];
+        $sailthru_list = $instance['sailthru_list'];
+        $order         = $field_order = $instance['field_order'];
+        $widget_id     = $this->id;
+
+        // Display the admin form
+        include SAILTHRU_PLUGIN_PATH . 'views/widget.subscribe.admin.php';
+
+    } // end form
+
+    /*--------------------------------------------*
+     * Action Functions
+     *--------------------------------------------*/
+
+
+    /**
+     * If enabled then a user is created in WordPress when a newsletter subscription is processed.
+     * This will only fire when the first_name is present so we can create a username
+     * it's recommended to uses a first and last name
+     */
+    function create_wp_account( $email, $options, $template = '' ) {
+
+        if ( false === apply_filters( 'sailthru_user_registration_enable', true ) ) {
+            return;
+        }
+
+        if ( isset( $options['vars']['first_name'] ) && ! empty( $options['vars']['first_name'] ) ) {
+                 $first_name = $options['vars']['first_name'];
+        } else {
+             $first_name = '';
+        }
+
+        if ( isset( $options['vars']['last_name'] ) && ! empty( $options['vars']['last_name'] ) ) {
+                 $last_name = $options['vars']['last_name'];
+        } else {
+             $last_name = '';
+        }
+
+        $nickname = sanitize_text_field( $first_name . ' ' . $last_name );
+
+        if ( empty( $nickname ) ) {
+            $nickname = $email;
+        }
+
+        $params = array(
+            'options'  => $options,
+            'template' => $template,
+        );
+
+        if ( false === email_exists( $email ) ) {
+            $random_password = wp_generate_password( $length = 12, $include_standard_special_chars = false );
+            $user            = wp_create_user( $email, $random_password, $email );
+            wp_new_user_notification( $user, null, 'user', $params );
+
+            $user_vars             = $options['vars'];
+            $user_vars['ID']       = $user;
+            $user_vars['nickname'] = $first_name . ' ' . $last_name;
+            unset( $user_vars['wp_widget_lists'] );
+            wp_update_user( $user_vars );
+            write_log( 'Account created:' . $email );
+        } else {
+            write_log( 'Account for ' . $email . ' exists' );
+        }
 
-	}
-
-
-
-	/**
-	 * Adds the WordPress Ajax Library to the frontend.
-	 */
-	public function add_ajax_library() {
-		echo '<script type="text/javascript">';
-		echo 'var sailthru_vars = ' . wp_json_encode( [ 'ajaxurl' => admin_url( 'admin-ajax.php' ) ]);
-		echo '</script>';
-	} // end add_ajax_library
-
-	/*--------------------------------------------------*/
-	/* Public Functions
-	/*--------------------------------------------------*/
+    }
+
+
+
+    /**
+     * Adds the WordPress Ajax Library to the frontend.
+     */
+    public function add_ajax_library() {
+        echo '<script type="text/javascript">';
+        echo 'var sailthru_vars = ' . wp_json_encode( [ 'ajaxurl' => admin_url( 'admin-ajax.php' ) ]);
+        echo '</script>';
+    } // end add_ajax_library
+
+    /*--------------------------------------------------*/
+    /* Public Functions
+    /*--------------------------------------------------*/
 
-	/**
-	 * Loads the Widget's text domain for localization and translation.
-	 */
-	public function load_widget_text_domain() {
-
-		load_plugin_textdomain( 'sailthru-for-wordpress', false, plugin_dir_path( __FILE__ ) . '/lang/' );
-
-	} // end load_widget_text_domain
-
-
-	/**
-	 * Registers and enqueues admin-specific JavaScript.
-	 */
-	public function register_admin_scripts() {
-
-		wp_enqueue_style( 'sailthru-subscribe-admin-styles', SAILTHRU_PLUGIN_URL . 'css/widget.subscribe.admin.css' );
-
-		wp_enqueue_script( 'jquery' );
-		wp_enqueue_script( 'jquery-ui-sortable' );
-	} // end register_admin_scripts
-
-	/**
-	 * Registers and enqueues widget-specific styles.
-	 */
-	public function register_widget_styles() {
-
-		wp_enqueue_style( 'sailthru-subscribe-widget-styles', SAILTHRU_PLUGIN_URL . 'css/widget.subscribe.css' );
-
-	} // end register_widget_styles
-
-	/**
-	 * Registers and enqueues widget-specific scripts.
-	 */
-	public function register_widget_scripts() {
-
-		wp_enqueue_script( 'sailthru-subscribe-script', SAILTHRU_PLUGIN_URL . 'js/widget.subscribe.js', array( 'jquery' ) );
-
-	} // end register_widget_scripts
-
-	/*--------------------------------------------------*/
-	/* Core Functions
-	/*--------------------------------------------------*/
+    /**
+     * Loads the Widget's text domain for localization and translation.
+     */
+    public function load_widget_text_domain() {
+
+        load_plugin_textdomain( 'sailthru-for-wordpress', false, plugin_dir_path( __FILE__ ) . '/lang/' );
+
+    } // end load_widget_text_domain
+
+
+    /**
+     * Registers and enqueues admin-specific JavaScript.
+     */
+    public function register_admin_scripts() {
+
+        wp_enqueue_style( 'sailthru-subscribe-admin-styles', SAILTHRU_PLUGIN_URL . 'css/widget.subscribe.admin.css' );
+
+        wp_enqueue_script( 'jquery' );
+        wp_enqueue_script( 'jquery-ui-sortable' );
+    } // end register_admin_scripts
+
+    /**
+     * Registers and enqueues widget-specific styles.
+     */
+    public function register_widget_styles() {
+
+        wp_enqueue_style( 'sailthru-subscribe-widget-styles', SAILTHRU_PLUGIN_URL . 'css/widget.subscribe.css' );
+
+    } // end register_widget_styles
+
+    /**
+     * Registers and enqueues widget-specific scripts.
+     */
+    public function register_widget_scripts() {
+
+        wp_enqueue_script( 'sailthru-subscribe-script', SAILTHRU_PLUGIN_URL . 'js/widget.subscribe.js', array( 'jquery' ) );
+
+    } // end register_widget_scripts
+
+    /*--------------------------------------------------*/
+    /* Core Functions
+    /*--------------------------------------------------*/
 
-	function return_response( $response ) {
-
-		header('Content-Type: application/json');
-		echo  wp_json_encode( $response );
-		exit();
-	}
+    function return_response( $response ) {
+
+        header('Content-Type: application/json');
+        echo  wp_json_encode( $response );
+        exit();
+    }
 
-	function add_subscriber() {
+    function add_subscriber() {
 
-		if ( ! wp_verify_nonce( $_POST['sailthru_nonce'], 'add_subscriber_nonce' ) ) {
-
-			$result = array(
-				'success' => false,
-				'message' => 'This form could not be validated, please refresh the page and try again. ',
-			);
-			$this->return_response( $result );
-		}
-
-		$email = ! empty( $_POST['email'] ) ? sanitize_email( $_POST['email'] ) : false;
+        if ( ! wp_verify_nonce( $_POST['sailthru_nonce'], 'add_subscriber_nonce' ) ) {
+
+            $result = array(
+                'success' => false,
+                'message' => 'This form could not be validated, please refresh the page and try again. ',
+            );
+            $this->return_response( $result );
+        }
+
+        $email = ! empty( $_POST['email'] ) ? sanitize_email( $_POST['email'] ) : false;
 
-		// check if email is valid, if not bail.
-		if ( ! is_email( $email ) ) {
-			$result['success'] = false;
-			$result['message'] = 'Please enter a valid email';
-			$this->return_response( $result );
-		}
+        // check if email is valid, if not bail.
+        if ( ! is_email( $email ) ) {
+            $result['success'] = false;
+            $result['message'] = 'Please enter a valid email';
+            $this->return_response( $result );
+        }
 
-		// check if email address exists in Sailthru.
-		$sailthru   = get_option( 'sailthru_setup_options' );
-		$api_key    = $sailthru['sailthru_api_key'];
-		$api_secret = $sailthru['sailthru_api_secret'];
-
-		$client = new WP_Sailthru_Client( $api_key, $api_secret );
-
-		if ( $client ) {
-
-			$options      = array();
-
-			// set the source
-			if ( isset( $_POST['source'] ) && ! empty( $_POST['source'] ) ) {
-				$source = sanitize_text_field( $_POST['source'] );
-			} else {
-				$source = get_bloginfo( 'url' );
-			}
-
-			// initialize vars with source.
-			$vars         = array( 'source' => $source );
-			$customfields = get_option( 'sailthru_forms_options' );
-			$key          = get_option( 'sailthru_forms_key' );
-
-			for ( $i = 0; $i < $key; $i++ ) {
-				$field_key = $i + 1;
-
-				if ( ! empty( $customfields[ $field_key ]['sailthru_customfield_name'] ) ) {
-					$name_stripped = preg_replace( '/[^\da-z]/i', '_', $customfields[ $field_key ]['sailthru_customfield_name'] );
-
-					if ( ! empty( $_POST[ 'custom_' . $name_stripped ] ) ) {
-						// check to see if this is an array or a string
-						if ( is_array( $_POST[ 'custom_' . $name_stripped ] ) ) {
-
-							foreach ( $_POST[ 'custom_' . $name_stripped ] as $val ) {
-								$var_name             = str_replace( 'custom_', '', $name_stripped );
-								$vars[ $var_name ] [] = sanitize_text_field( $val );
-							}
-						} else {
-							$var_name          = str_replace( 'custom_', '', $name_stripped );
-							$vars[ $var_name ] = sanitize_text_field( $_POST[ 'custom_' . $name_stripped ] );
-						}
-					}
-				}
-			} //end for loop
-
-
-			$subscribe_to_lists  = array();
-			$sailthru_email_list = sanitize_text_field( $_POST['sailthru_email_list'] );
-			if ( ! empty( $sailthru_email_list ) ) {
-
-				// check for double opt in setting
-				if ( isset( $customfields['sailthru_double_opt_in'] ) && true === $customfields['sailthru_double_opt_in'] ) {
-					$double_opt_in = true;
-				} else {
-					$double_opt_in = false;
-				}
-
-				$lists = explode( ',', $sailthru_email_list );
-
-				foreach ( $lists as $key => $list ) {
-					$subscribe_to_lists[ $list ] = 1;
-				}
-
-				$options['lists'] = $subscribe_to_lists;
-
-			} else {
-
-				$options['lists'] = array( 'Sailthru Subscribe Widget' => 1 ); // subscriber is an orphan
-
-			}
-
-			// clean up vars
-			unset( $vars['email'] );
-			unset( $vars['sailthru_nonce'] );
-			unset( $vars['action'] );
-
-			$options['vars'] = $vars;
-
-			$data = array(
-				'id'     => $email,
-				'fields' => array(
-					'lists' => 1,
-					'keys'  => 1,
-				),
-			);
-
-			$profile = false;
-
-			try {
-				$profile = $client->apiGet( 'user', $data );
-			} catch ( Sailthru_Client_Exception $e ) {
-
-				if ( ! strpos( $e->getMessage(), 'User not found with email' ) ) {
-					write_log( $e->getMessage() );
-				}
-			}
-
-            		$recaptcha_token = sanitize_text_field( $_POST['captcha_token'] );
-
-			if ( ! empty( $sailthru['google_recaptcha_site_key'] ) && ! empty( $sailthru['google_recaptcha_secret'] ) && ! empty( $recaptcha_token ) ) {
-				write_log( "reCaptcha enabled, verifying" );
-				try {
-					$response = wp_remote_get( 'https://www.google.com/recaptcha/api/siteverify?secret=' . $sailthru['google_recaptcha_secret'] . '&response=' . $recaptcha_token );
-					$body = wp_remote_retrieve_body( $response );
-					$data = json_decode( $body, true );
-					if ( false == $data['success'] ) {
-						// failed, send an error message here, but keep it vague
-						$this->return_response(
-							array(
-								'success' => false,
-								'message' => 'Sorry, something went wrong and we could not subscribe you.'
-							)
-						);
-					}
-				} catch ( Exception $e ) {
-					write_log( $e );
-				}
-			}
-
-			$reset_optout_status = isset( $_POST['reset_optout_status'] ) && ! empty( $_POST['reset_optout_status'] ) ? 'none': '';
-
-			$profile_data = array(
-				'id' => $email,
-				'key' => 'email',
-				'vars' => $options['vars'],
-				'lists' => $options['lists'],
-				'optout_email' => $reset_optout_status
-			);
-
-			if ( ! empty( $profile ) ) {
-
-				if ( isset( $profile['lists'] ) && count( $profile['lists'] ) > 0 ) {
-
-					// now we need to check which lists they are being subscribed to which they are not a member of.
-					foreach ( $options['lists'] as $list_name => $list_val ) {
-
-						if ( ! array_key_exists( $list_name, $profile['lists'] ) ) {
-							$new_lists[] = $list_name;
-						}
-					}
-				} else {
-					// all of the lists are new lists
-					$new_lists = $options['lists'];
-				}
-
-				try {
-					$client->apiPost( 'user', $profile_data );
-					$new_lists = $options['lists'];
-
-				} catch ( Sailthru_Client_Exception $e ) {
-					write_log( $e );
-				}
-
-			} else {
-
-				try {
-					$client->apiPost( 'user', $profile_data );
-					$new_lists = $options['lists'];
-
-				} catch ( Sailthru_Client_Exception $e ) {
-					write_log( $e );
-				}
-			}
-
-			// check if the user is a new subscriber to any lists.
-			$new_subscriber = count( $new_lists ) > 0 ? true : false;
-
-			if ( isset( $customfields['sailthru_welcome_template'] ) && ! empty( $customfields['sailthru_welcome_template'] ) ) {
-
-				if ( $new_subscriber ) {
-
-					try {
-						$client->send( $customfields['sailthru_welcome_template'], $email, $vars );
-					} catch ( Sailthru_Client_Exception $e ) {
-						write_log( $e );
-					}
-				}
-			}
-
-			// Handle the Event If it's been set to fire.
-			if ( isset( $_POST['lo_event_name'] ) && ! empty( $_POST['lo_event_name'] ) ) {
-				$event = sanitize_text_field( $_POST['lo_event_name'] );
-			} else {
-				$event = false;
-			}
-
-			if ( $event ) {
-
-				$event_data = array(
-					'id'    => $email,
-					'event' => $event,
-					'vars'  => $options['vars'],
-				);
-
-				try {
-					$client->apiPost( 'event', $event_data );
-				} catch ( Sailthru_Client_Exception $e ) {
-					write_log( $e );
-				}
-			}
-
-			if ( has_filter( 'sailthru_user_registration_enable' ) ) {
-				$setup    = get_option( 'sailthru_setup_options' );
-				$template = '';
-				if ( isset( $setup['sailthru_setup_new_user_override_template'] ) && ! empty( $setup['sailthru_setup_new_user_override_template'] ) ) {
-					$template = $setup['sailthru_setup_new_user_override_template'];
-				}
-				$this->create_wp_account( $email, $options, $template );
-			}
-
-			// format response.
-			$result = array(
-				'success' => true,
-				'message' => 'User Subscribed',
-			);
-
-			$this->return_response( $result );
-
-		} else {
-
-			// format response.
-			$result['success'] = false;
-			$result['message'] = 'Sorry, something went wrong and we could not subscribe you.';
-			$this->return_response( $result );
-		}
-
-	}
+        // check if email address exists in Sailthru.
+        $sailthru   = get_option( 'sailthru_setup_options' );
+        $api_key    = $sailthru['sailthru_api_key'];
+        $api_secret = $sailthru['sailthru_api_secret'];
+
+        $client = new WP_Sailthru_Client( $api_key, $api_secret );
+
+        if ( $client ) {
+
+            $options      = array();
+
+            // set the source
+            if ( isset( $_POST['source'] ) && ! empty( $_POST['source'] ) ) {
+                $source = sanitize_text_field( $_POST['source'] );
+            } else {
+                $source = get_bloginfo( 'url' );
+            }
+
+            // initialize vars with source.
+            $vars         = array( 'source' => $source );
+            $customfields = get_option( 'sailthru_forms_options' );
+            $key          = get_option( 'sailthru_forms_key' );
+
+            for ( $i = 0; $i < $key; $i++ ) {
+                $field_key = $i + 1;
+
+                if ( ! empty( $customfields[ $field_key ]['sailthru_customfield_name'] ) ) {
+                    $name_stripped = preg_replace( '/[^\da-z]/i', '_', $customfields[ $field_key ]['sailthru_customfield_name'] );
+
+                    if ( ! empty( $_POST[ 'custom_' . $name_stripped ] ) ) {
+                        // check to see if this is an array or a string
+                        if ( is_array( $_POST[ 'custom_' . $name_stripped ] ) ) {
+
+                            foreach ( $_POST[ 'custom_' . $name_stripped ] as $val ) {
+                                $var_name             = str_replace( 'custom_', '', $name_stripped );
+                                $vars[ $var_name ] [] = sanitize_text_field( $val );
+                            }
+                        } else {
+                            $var_name          = str_replace( 'custom_', '', $name_stripped );
+                            $vars[ $var_name ] = sanitize_text_field( $_POST[ 'custom_' . $name_stripped ] );
+                        }
+                    }
+                }
+            } //end for loop
+
+
+            $subscribe_to_lists  = array();
+            $sailthru_email_list = sanitize_text_field( $_POST['sailthru_email_list'] );
+            if ( ! empty( $sailthru_email_list ) ) {
+
+                // check for double opt in setting
+                if ( isset( $customfields['sailthru_double_opt_in'] ) && true === $customfields['sailthru_double_opt_in'] ) {
+                    $double_opt_in = true;
+                } else {
+                    $double_opt_in = false;
+                }
+
+                $lists = explode( ',', $sailthru_email_list );
+
+                foreach ( $lists as $key => $list ) {
+                    $subscribe_to_lists[ $list ] = 1;
+                }
+
+                $options['lists'] = $subscribe_to_lists;
+
+            } else {
+
+                $options['lists'] = array( 'Sailthru Subscribe Widget' => 1 ); // subscriber is an orphan
+
+            }
+
+            // clean up vars
+            unset( $vars['email'] );
+            unset( $vars['sailthru_nonce'] );
+            unset( $vars['action'] );
+
+            $options['vars'] = $vars;
+
+            $data = array(
+                'id'     => $email,
+                'fields' => array(
+                    'lists' => 1,
+                    'keys'  => 1,
+                ),
+            );
+
+            $profile = false;
+
+            try {
+                $profile = $client->apiGet( 'user', $data );
+            } catch ( Sailthru_Client_Exception $e ) {
+
+                if ( ! strpos( $e->getMessage(), 'User not found with email' ) ) {
+                    write_log( $e->getMessage() );
+                }
+            }
+
+                    $recaptcha_token = sanitize_text_field( $_POST['captcha_token'] );
+
+            if ( ! empty( $sailthru['google_recaptcha_site_key'] ) && ! empty( $sailthru['google_recaptcha_secret'] ) && ! empty( $recaptcha_token ) ) {
+                write_log( "reCaptcha enabled, verifying" );
+                try {
+                    $response = wp_remote_get( 'https://www.google.com/recaptcha/api/siteverify?secret=' . $sailthru['google_recaptcha_secret'] . '&response=' . $recaptcha_token );
+                    $body = wp_remote_retrieve_body( $response );
+                    $data = json_decode( $body, true );
+                    if ( false == $data['success'] ) {
+                        // failed, send an error message here, but keep it vague
+                        $this->return_response(
+                            array(
+                                'success' => false,
+                                'message' => 'Sorry, something went wrong and we could not subscribe you.'
+                            )
+                        );
+                    }
+                } catch ( Exception $e ) {
+                    write_log( $e );
+                }
+            }
+
+            $profile_data = array(
+                'id' => $email,
+                'key' => 'email',
+                'vars' => $options['vars'],
+                'lists' => $options['lists'],
+            );
+
+            $should_update_optout = isset( $_POST['reset_optout_status'] ) && ! empty( $_POST['reset_optout_status'] ) ? 'none': '';
+            if ($should_update_optout) {
+                $profile_data['optout_email'] = 'none';
+            }
+
+            if ( ! empty( $profile ) ) {
+
+                if ( isset( $profile['lists'] ) && count( $profile['lists'] ) > 0 ) {
+
+                    // now we need to check which lists they are being subscribed to which they are not a member of.
+                    foreach ( $options['lists'] as $list_name => $list_val ) {
+
+                        if ( ! array_key_exists( $list_name, $profile['lists'] ) ) {
+                            $new_lists[] = $list_name;
+                        }
+                    }
+                } else {
+                    // all of the lists are new lists
+                    $new_lists = $options['lists'];
+                }
+
+                try {
+                    $client->apiPost( 'user', $profile_data );
+                    $new_lists = $options['lists'];
+
+                } catch ( Sailthru_Client_Exception $e ) {
+                    write_log( $e );
+                }
+
+            } else {
+
+                try {
+                    $client->apiPost( 'user', $profile_data );
+                    $new_lists = $options['lists'];
+
+                } catch ( Sailthru_Client_Exception $e ) {
+                    write_log( $e );
+                }
+            }
+
+            // check if the user is a new subscriber to any lists.
+            $new_subscriber = count( $new_lists ) > 0 ? true : false;
+
+            if ( isset( $customfields['sailthru_welcome_template'] ) && ! empty( $customfields['sailthru_welcome_template'] ) ) {
+
+                if ( $new_subscriber ) {
+
+                    try {
+                        $client->send( $customfields['sailthru_welcome_template'], $email, $vars );
+                    } catch ( Sailthru_Client_Exception $e ) {
+                        write_log( $e );
+                    }
+                }
+            }
+
+            // Handle the Event If it's been set to fire.
+            if ( isset( $_POST['lo_event_name'] ) && ! empty( $_POST['lo_event_name'] ) ) {
+                $event = sanitize_text_field( $_POST['lo_event_name'] );
+            } else {
+                $event = false;
+            }
+
+            if ( $event ) {
+
+                $event_data = array(
+                    'id'    => $email,
+                    'event' => $event,
+                    'vars'  => $options['vars'],
+                );
+
+                try {
+                    $client->apiPost( 'event', $event_data );
+                } catch ( Sailthru_Client_Exception $e ) {
+                    write_log( $e );
+                }
+            }
+
+            if ( has_filter( 'sailthru_user_registration_enable' ) ) {
+                $setup    = get_option( 'sailthru_setup_options' );
+                $template = '';
+                if ( isset( $setup['sailthru_setup_new_user_override_template'] ) && ! empty( $setup['sailthru_setup_new_user_override_template'] ) ) {
+                    $template = $setup['sailthru_setup_new_user_override_template'];
+                }
+                $this->create_wp_account( $email, $options, $template );
+            }
+
+            // format response.
+            $result = array(
+                'success' => true,
+                'message' => 'User Subscribed',
+            );
+
+            $this->return_response( $result );
+
+        } else {
+
+            // format response.
+            $result['success'] = false;
+            $result['message'] = 'Sorry, something went wrong and we could not subscribe you.';
+            $this->return_response( $result );
+        }
+
+    }
 
 
 
@@ -554,63 +556,63 @@ register_activation_hook( __FILE__, array( 'Sailthru_Subscribe', 'activate' ) );
  * Register Sailthru Subscribe Widget
  */
 function sailthru_register_subscribe_widget() {
-	register_widget( 'Sailthru_Subscribe_Widget' );
+    register_widget( 'Sailthru_Subscribe_Widget' );
 }
 add_action( 'widgets_init', 'sailthru_register_subscribe_widget' );
 
 function sailthru_widget_shortcode( $atts ) {
 
-	// Configure defaults and extract the attributes into variables
-	extract(
-		shortcode_atts(
-			array(
-				'fields'          => 'name',
-				'modal'           => 'false',
-				'text'            => 'Subscribe',
-				'sailthru_list'   => array(),
-				'field_order'     => '',
-				'using_shortcode' => true,
-			), $atts
-		)
-	);
+    // Configure defaults and extract the attributes into variables
+    extract(
+        shortcode_atts(
+            array(
+                'fields'          => 'name',
+                'modal'           => 'false',
+                'text'            => 'Subscribe',
+                'sailthru_list'   => array(),
+                'field_order'     => '',
+                'using_shortcode' => true,
+            ), $atts
+        )
+    );
 
-	if ( empty( $atts['using_shortcode'] ) ) {
-		$atts['using_shortcode'] = true;
-	}
+    if ( empty( $atts['using_shortcode'] ) ) {
+        $atts['using_shortcode'] = true;
+    }
 
-	if ( empty( $atts['text'] ) ) {
-		$atts['text'] = 'Subscribe to our newsletter';
-	}
+    if ( empty( $atts['text'] ) ) {
+        $atts['text'] = 'Subscribe to our newsletter';
+    }
 
-	// the widget doesn't render if there is no email list specified.
-	if ( empty( $atts['sailthru_list'] ) ) {
-		$atts['sailthru_list'] = array( 'Sailthru Wordpress Shortcode' );
-	}
+    // the widget doesn't render if there is no email list specified.
+    if ( empty( $atts['sailthru_list'] ) ) {
+        $atts['sailthru_list'] = array( 'Sailthru Wordpress Shortcode' );
+    }
 
-	if ( ! empty( $atts['modal'] ) ) {
+    if ( ! empty( $atts['modal'] ) ) {
 
-		if ( 'true' === $atts['modal'] ) {
-			$before_widget = '<div id="mask"></div><a class="show_shortcode" href="#">' . esc_html( $atts['text'] ) . '</a><div id="sailthru-modal"><div class="sailthru_shortcode_hidden">';
-			$after_widget  = '</div></div>';
-		} else {
-			$before_widget = '<div class="sailthru_shortcode">';
-			$after_widget  = '</div>';
-		}
-	} else {
-		$before_widget = '<div class="sailthru_shortcode">';
-		$after_widget  = '</div>';
-	}
+        if ( 'true' === $atts['modal'] ) {
+            $before_widget = '<div id="mask"></div><a class="show_shortcode" href="#">' . esc_html( $atts['text'] ) . '</a><div id="sailthru-modal"><div class="sailthru_shortcode_hidden">';
+            $after_widget  = '</div></div>';
+        } else {
+            $before_widget = '<div class="sailthru_shortcode">';
+            $after_widget  = '</div>';
+        }
+    } else {
+        $before_widget = '<div class="sailthru_shortcode">';
+        $after_widget  = '</div>';
+    }
 
-	$args = array(
-		'before_widget' => $before_widget,
-		'after_widget'  => '</div>',
-		'before_title'  => '<div class="widget-title">',
-		'after_title'   => $after_widget,
-	);
+    $args = array(
+        'before_widget' => $before_widget,
+        'after_widget'  => '</div>',
+        'before_title'  => '<div class="widget-title">',
+        'after_title'   => $after_widget,
+    );
 
-	ob_start();
-	the_widget( 'Sailthru_Subscribe_Widget', $atts, $args );
-	$output = ob_get_clean();
-	return $output;
+    ob_start();
+    the_widget( 'Sailthru_Subscribe_Widget', $atts, $args );
+    $output = ob_get_clean();
+    return $output;
 }
 add_shortcode( 'sailthru_widget', 'sailthru_widget_shortcode' );


### PR DESCRIPTION
Added a checkbox to the Sailthru Subscribe widget to automatically set users' opt-in status to valid on subscribe. This works both for the footer widget and the shortcode.

Additionally, integration with reCaptcha is now supported. The validation is done server-side by the Sailthru plugin.