### PR TITLE
VIP: Clear cache because of 5.3 changes handling for user_activation_key

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,9 +1,9 @@
 === Sailthru for WordPress ===
-Contributors: asilverman, nickgundry, sailthru-wp, automattic, irms, zackify, natebot
+Contributors: brownac, lcooper, asilverman, nickgundry, sailthru-wp, automattic, irms, zackify, natebot
 Tags: personalization, email,
 Requires at least: 3.6
 Tested up to: 4.9.5
-Stable tag: 3.3.0
+Stable tag: 3.3.1
 
 This plugin  provides fast and easy integration of the core Sailthru features into your Wordpress site.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 # Changelog
+## v3.3.1 (2019-11-18)
+VIP: Clear cache because of 5.3 changes handling for user_activation_key
+
 ## v3.3.0 (2018-11-12)
 Address codestyle issues for VIP
 

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name: Sailthru for WordPress
 Plugin URI: http://sailthru.com/
 Description: Add the power of Sailthru to your WordPress set up.
-Version: 3.3.0
+Version: 3.3.1
 Author: Sailthru
 Author URI: http://sailthru.com
 Author Email: integrations@sailthru.com
@@ -35,7 +35,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  * @var   const    $version    The current version of the plugin.
  */
 if ( ! defined( 'SAILTHRU_PLUGIN_VERSION' ) ) {
-	define( 'SAILTHRU_PLUGIN_VERSION', '3.3.0' );
+	define( 'SAILTHRU_PLUGIN_VERSION', '3.3.1' );
 }
 
 if ( ! defined( 'SAILTHRU_PLUGIN_PATH' ) ) {

--- a/sailthru_mail.php
+++ b/sailthru_mail.php
@@ -113,6 +113,7 @@ if ( get_option( 'sailthru_setup_complete' ) && ! function_exists( 'wp_mail' ) )
 				}
 				$hashed = time() . ':' . $wp_hasher->HashPassword( $key );
 				$wpdb->update( $wpdb->users, array( 'user_activation_key' => $hashed ), array( 'user_login' => $user->user_login ) );
+				clean_user_cache( $user_id );
 
 				$switched_locale = switch_to_locale( get_user_locale( $user ) );
 


### PR DESCRIPTION
WordPress 5.3 has updated the way how user_activation_key is being read. It used to be read directly from the database, but in https://core.trac.wordpress.org/changeset/45714 and https://core.trac.wordpress.org/changeset/45716 this has been updated, so it gets read from the WP_User object.

This means that any code updating the user_activation_key for a user has to properly clean the caches, otherwise the key won’t be properly read.