### PR TITLE
Add load event listener to only initialize JS when it gets loaded.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: brownac, lcooper, asilverman, nickgundry, sailthru-wp, automattic,
 Tags: personalization, email,
 Requires at least: 3.6
 Tested up to: 4.9.5
-Stable tag: 3.4.2
+Stable tag: 3.4.3
 
 This plugin  provides fast and easy integration of the core Sailthru features into your Wordpress site.
 

--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,7 @@
 Contributors: brownac, lcooper, asilverman, nickgundry, sailthru-wp, automattic, irms, zackify, natebot
 Tags: personalization, email,
 Requires at least: 3.6
-Tested up to: 4.9.5
+Tested up to: 5.4
 Stable tag: 3.4.3
 
 This plugin  provides fast and easy integration of the core Sailthru features into your Wordpress site.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v3.4.3 (2020-04-07)
+Fixed bug where Sailthru onsite JS would sometimes fail to initialize due to asynchronous loading of scripts
+
 ## v3.4.2 (2020-03-26)
 Fixed bug where onsite JS taking too long to load would prevent some pages from loading
 

--- a/classes/class-sailthru-horizon.php
+++ b/classes/class-sailthru-horizon.php
@@ -250,7 +250,7 @@ class Sailthru_Horizon {
 
 	public function spm_async( $tag, $handle, $src ) {
 		if ( $handle == 'personalize_js' ) {
-			return "<script src='" . esc_url( $src ) . "' type='text/javascript' onload='sailthru_init();' async></script>";
+			return "<script src='" . esc_url( $src ) . "' type='text/javascript' async></script>";
 		}
 		return $tag;
 	}

--- a/js/tag.js
+++ b/js/tag.js
@@ -1,17 +1,20 @@
 sailthru_init = function(){
-    if (tag.isCustom) {
-        jQuery(function($) {
-            Sailthru.init({
-                customerId: tag.options.customerId,
-                isCustom: true,
-                autoTrackPageview: tag.options.autoTrackPageview,
-                useStoredTags: tag.options.useStoredTags,
-                excludeContent: tag.options.excludeContent,
+    window.addEventListener("load", function() {
+        console.info("Sailthru onsite JS is loaded. Initializing Sailthru...");
+        if (tag.isCustom) {
+            jQuery(function($) {
+                Sailthru.init({
+                    customerId: tag.options.customerId,
+                    isCustom: true,
+                    autoTrackPageview: tag.options.autoTrackPageview,
+                    useStoredTags: tag.options.useStoredTags,
+                    excludeContent: tag.options.excludeContent,
+                });
             });
-        });
-    } else {
-        Sailthru.init({
-            customerId: tag.options.customerId
-        });
-    }
-}
+        } else {
+            Sailthru.init({
+                customerId: tag.options.customerId
+            });
+        }
+    });
+};

--- a/js/tag.js
+++ b/js/tag.js
@@ -1,20 +1,18 @@
-sailthru_init = function(){
-    window.addEventListener("load", function() {
-        console.info("Sailthru onsite JS is loaded. Initializing Sailthru...");
-        if (tag.isCustom) {
-            jQuery(function($) {
-                Sailthru.init({
-                    customerId: tag.options.customerId,
-                    isCustom: true,
-                    autoTrackPageview: tag.options.autoTrackPageview,
-                    useStoredTags: tag.options.useStoredTags,
-                    excludeContent: tag.options.excludeContent,
-                });
-            });
-        } else {
+window.addEventListener("load", function() {
+    console.info("Sailthru onsite JS is loaded. Initializing Sailthru...");
+    if (tag.isCustom) {
+        jQuery(function($) {
             Sailthru.init({
-                customerId: tag.options.customerId
+                customerId: tag.options.customerId,
+                isCustom: true,
+                autoTrackPageview: tag.options.autoTrackPageview,
+                useStoredTags: tag.options.useStoredTags,
+                excludeContent: tag.options.excludeContent,
             });
-        }
-    });
-};
+        });
+    } else {
+        Sailthru.init({
+            customerId: tag.options.customerId
+        });
+    }
+});

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name: Sailthru for WordPress
 Plugin URI: http://sailthru.com/
 Description: Add the power of Sailthru to your WordPress set up.
-Version: 3.4.2
+Version: 3.4.3
 Author: Sailthru
 Author URI: http://sailthru.com
 Author Email: integrations@sailthru.com
@@ -35,7 +35,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  * @var   const    $version    The current version of the plugin.
  */
 if ( ! defined( 'SAILTHRU_PLUGIN_VERSION' ) ) {
-	define( 'SAILTHRU_PLUGIN_VERSION', '3.4.2' );
+	define( 'SAILTHRU_PLUGIN_VERSION', '3.4.3' );
 }
 
 if ( ! defined( 'SAILTHRU_PLUGIN_PATH' ) ) {


### PR DESCRIPTION
**Problem**: Certain clients that use this integration may load a lot of scripts onto their page, thereby increasing the time to load for onsite JS. This will lead to `Sailthru.init` failing to run, and pageviews failing to be tracked.

**Solution**: Add event listener to only initialize Sailthru JS once all the other content on the page has loaded (see [documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event)).

**Issue**: [IN-1267](https://sailthru.atlassian.net/browse/IN-1267)