### PR TITLE
Update PHPMailer to use new namespaced class

### DIFF
--- a/classes/class-sailthru-mailer.php
+++ b/classes/class-sailthru-mailer.php
@@ -1,7 +1,9 @@
 <?php
 
-require_once ABSPATH . WPINC . '/class-phpmailer.php';
-require_once ABSPATH . WPINC . '/class-smtp.php';
+use PHPMailer\PHPMailer\PHPMailer;
+
+require_once ABSPATH . WPINC . '/PHPMailer/PHPMailer.php';
+require_once ABSPATH . WPINC . '/PHPMailer/SMTP.php';
 
 
 class SailthruMailer extends PHPMailer {

--- a/classes/class-sailthru-mailer.php
+++ b/classes/class-sailthru-mailer.php
@@ -1,10 +1,12 @@
 <?php
 
+// Work-around for 5.5.1
 use PHPMailer\PHPMailer\PHPMailer;
 
 require_once ABSPATH . WPINC . '/PHPMailer/PHPMailer.php';
+require_once ABSPATH . WPINC . '/PHPMailer/Exception.php';
 require_once ABSPATH . WPINC . '/PHPMailer/SMTP.php';
-
+// End work-around for 5.5.1
 
 class SailthruMailer extends PHPMailer {
 


### PR DESCRIPTION
With the 5.5 release of WordPress, PHPMailer was moved into its own namespace and left `class-phpmailer.php` marked as deprecated. This PR still needs backwards compatibility for < 5.5 though.

Related https://core.trac.wordpress.org/ticket/41750