### PR TITLE
Revert "[IN-1791] Fix Signup Widget Error: Unset Welcome Template Break Signup Widget (v3.6.3)"

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,9 +13,6 @@ Fixed warning where post_type not set properly
 Supports Wordpress version 5.5.
 This version isn't backwards compatible with older Wordpress versions.
 
-## v3.6.3 (2021-01-20)
-Fixed bug where an unset Welcome Template breaks the signup widget
-
 ## v3.6.2 (2020-12-03)
 Fixed warning where post_type not set properly
 

--- a/widget.subscribe.php
+++ b/widget.subscribe.php
@@ -505,27 +505,27 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 		return $subscribe_to_lists;
 	}
 
-	private function post_user_profile( $client, $profile_data ): void {
-		try {
-			$client->apiPost( 'user', $profile_data );
-		} catch ( Sailthru_Client_Exception $e ) {
-			write_log( $e );
-		}
-	}
+    private function post_user_profile( $client, $profile_data ): void {
+        try {
+            $client->apiPost( 'user', $profile_data );
+        } catch ( Sailthru_Client_Exception $e ) {
+            write_log( $e );
+        }
+    }
 
-	private function should_send_welcome_template( $custom_fields, array $new_lists ): bool {
+	private function should_send_welcome_template( array $custom_fields, array $new_lists ): bool {
 		return ! empty($custom_fields['sailthru_welcome_template']) && ! empty($new_lists);
 	}
 
 	private function send_template( $client, string $template, string $email, array $vars ): void {
-		try {
-			$client->send( $template, $email, $vars );
-		} catch ( Sailthru_Client_Exception $e ) {
-			write_log( $e );
-		}
-	}
+        try {
+            $client->send( $template, $email, $vars );
+        } catch ( Sailthru_Client_Exception $e ) {
+            write_log( $e );
+        }
+    }
 
-	private function filter_out_existing_lists( $profile, array $subscribe_to_lists ): array {
+	private function filter_out_existing_lists( array $profile, array $subscribe_to_lists ): array {
 		if (empty($profile)) {
 			return array_keys( $subscribe_to_lists );
 		}


### PR DESCRIPTION
Reverts sailthru/sailthru-wordpress-plugin#94