### PR TITLE
[IN-1884] Basic implementation of delete posts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ img/.DS_Store
 *.sublime-workspace
 .vscode/launch.json
 .vscode/settings.json
+.idea/shelf
+.idea/sonarlint

--- a/classes/class-wp-sailthru-client.php
+++ b/classes/class-wp-sailthru-client.php
@@ -86,7 +86,7 @@ class WP_Sailthru_Client extends Sailthru_Client {
 
 		$url = $this->api_uri . '/' . $action;
 
-		if ( 'GET' === $method ) {
+		if ( $method === 'GET' || $method === 'DELETE' ) {
 			$url_with_params = $url;
 			if ( count( $data ) > 0 ) {
 				$url_with_params .= '?' . http_build_query( $data );
@@ -122,6 +122,8 @@ class WP_Sailthru_Client extends Sailthru_Client {
 			} else {
 				$reply = wp_remote_get( $url, $data );
 			}
+		} else if ( $method === 'DELETE' ) {
+			$reply = wp_remote_request( $url, [ 'method' => 'DELETE' ] );
 		} else {
 			$reply = wp_remote_post( $url, $data );
 		}

--- a/lib/Sailthru_Client.php
+++ b/lib/Sailthru_Client.php
@@ -1498,6 +1498,8 @@ class Sailthru_Client {
 
     /**
      * Perform an HTTP request, checking for curl extension support
+	 *
+	 * @see WP_Sailthru_Client::httpRequestCurl() for override of httpRequestCurl
      *
      * @param $action
      * @param array $data
@@ -1507,6 +1509,7 @@ class Sailthru_Client {
      * @throws Sailthru_Client_Exception
      */
     protected function httpRequest($action, $data, $method = 'POST', $options = [ ]) {
+		// See WP_Sailthru_Client::httpRequestCurl() for this override
         $response = $this->{$this->http_request_type}($action, $data, $method, $options);
         $json = json_decode($response, true);
         if ($json === NULL) {


### PR DESCRIPTION
Added support to delete posts. The changes are minimal to avoid side effects breaking other things. The important thing to notice is that moving items to trash is what deletes them from Sailthru and not permanent deletion. This is important because items are only pushed to Sailthru when they are published (at which point they have a permalink that is used as key in Sailthru Content API) so it makes sense to delete from Sailthru when they are moved to trash (and are not published anymore and also lose their permalink)