### PR TITLE
[IN-1950] Added post object to sailthru_horizon_meta_tags filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,4 @@ img/.DS_Store
 *.sublime-workspace
 .vscode/launch.json
 .vscode/settings.json
-.idea/shelf
-.idea/sonarlint
+.idea

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: sailthru-wp
 Tags: personalization, email,
 Requires at least: 5.5
 Tested up to: 5.7
-Stable tag: 4.1.1
+Stable tag: 4.2.0
 
 Provides an integration with Sailthru
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v4.2.0 (2021-07-06)
+Added post object to sailthru_horizon_meta_tags filter
+
 ## v4.1.1 (2021-05-25)
 Fixed Bulk Edit not propagating category and Wordpress tags properly
 

--- a/classes/class-sailthru-content.php
+++ b/classes/class-sailthru-content.php
@@ -323,7 +323,7 @@ class Sailthru_Content_Settings {
 		$data['tags'] = $this->generate_tags( $post->ID);
 
 		// Apply any filters to the tags.
-		$data['tags'] = apply_filters( 'sailthru_horizon_meta_tags', ['sailthru.tags' => $data['tags'] ] ) ;
+		$data['tags'] = apply_filters( 'sailthru_horizon_meta_tags', ['sailthru.tags' => $data['tags'], 'post' => $post] ) ;
 
 		// Check if the filter has returned sailthru.tags and convert to string.
 		if ( is_array( $data['tags'] ) && isset ( $data['tags']['sailthru.tags'] ) ) {

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name:        Sailthru for WordPress
 Plugin URI:         http://sailthru.com/
 Description:        Add the power of Sailthru to your WordPress set up.
-Version:            4.1.1
+Version:            4.2.0
 Requires at least:  5.5
 Author:             Sailthru
 Author URI:         http://sailthru.com
@@ -36,7 +36,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  * @var   const    $version    The current version of the plugin.
  */
 if ( ! defined( 'SAILTHRU_PLUGIN_VERSION' ) ) {
-	define( 'SAILTHRU_PLUGIN_VERSION', '4.1.1' );
+	define( 'SAILTHRU_PLUGIN_VERSION', '4.2.0' );
 }
 
 if ( ! defined( 'SAILTHRU_PLUGIN_PATH' ) ) {


### PR DESCRIPTION
We have a client that needs access to post object in sailthru_horizon_meta_tags filter in bulk edits. This is a minor change to add it.