### PR TITLE
[INT-889] Removed backslashes when using quotes

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: sailthru-wp
 Tags: personalization, email,
 Requires at least: 5.5
 Tested up to: 5.7
-Stable tag: 4.3.5
+Stable tag: 4.3.6
 
 Provides an integration with Sailthru
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 # Changelog
+## v4.3.6 (2024-05-28)
+Removed backslashes when using quotes
+
 ## v4.3.5 (2024-04-08)
 Removed commented code inside the if condition
 

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name:        Sailthru for WordPress
 Plugin URI:         http://sailthru.com/
 Description:        Add the power of Sailthru to your WordPress set up.
-Version:            4.3.5
+Version:            4.3.6
 Requires at least:  5.5
 Author:             Sailthru
 Author URI:         http://sailthru.com
@@ -36,7 +36,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  * @var   const    $version    The current version of the plugin.
  */
 if ( ! defined( 'SAILTHRU_PLUGIN_VERSION' ) ) {
-	define( 'SAILTHRU_PLUGIN_VERSION', '4.3.5' );
+	define( 'SAILTHRU_PLUGIN_VERSION', '4.3.6' );
 }
 
 if ( ! defined( 'SAILTHRU_PLUGIN_PATH' ) ) {

--- a/widget.subscribe.php
+++ b/widget.subscribe.php
@@ -353,7 +353,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 							}
 						} else {
 							$var_name          = str_replace( 'custom_', '', $name_stripped );
-                                                        $vars[ $var_name ] = sanitize_text_field( $_POST[ 'custom_' . $name_stripped ] ); 
+                                                        $vars[ $var_name ] = sanitize_text_field( $_POST[ 'custom_' . $name_stripped ] );
 						}
 					}
 				}

--- a/widget.subscribe.php
+++ b/widget.subscribe.php
@@ -353,7 +353,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 							}
 						} else {
 							$var_name          = str_replace( 'custom_', '', $name_stripped );
-                                                        $vars[ $var_name ] = sanitize_text_field( $_POST [ 'custom_' . $name_stripped ] );
+                                                        $vars[ $var_name ] = sanitize_text_field( $_POST[ 'custom_' . $name_stripped ] );
 						}
 					}
 				}

--- a/widget.subscribe.php
+++ b/widget.subscribe.php
@@ -342,7 +342,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 
 				if ( ! empty( $customfields[ $field_key ]['sailthru_customfield_name'] ) ) {
 					$name_stripped = preg_replace( '/[^\da-z]/i', '_', $customfields[ $field_key ]['sailthru_customfield_name'] );
-                    $name_stripped = stripslashes($name_stripped);
+                                $name_stripped = stripslashes($name_stripped);
 					if ( ! empty( $_POST[ 'custom_' . $name_stripped ] ) ) {
 						// check to see if this is an array or a string
 						if ( is_array( $_POST[ 'custom_' . $name_stripped ] ) ) {
@@ -353,7 +353,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 							}
 						} else {
 							$var_name          = str_replace( 'custom_', '', $name_stripped );
-                            $vars[$var_name] = stripslashes(sanitize_text_field($_POST['custom_' . $name_stripped]));
+                                        $vars[$var_name] = stripslashes(sanitize_text_field($_POST['custom_' . $name_stripped]));
 						}
 					}
 				}

--- a/widget.subscribe.php
+++ b/widget.subscribe.php
@@ -342,7 +342,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 
 				if ( ! empty( $customfields[ $field_key ]['sailthru_customfield_name'] ) ) {
 					$name_stripped = preg_replace( '/[^\da-z]/i', '_', $customfields[ $field_key ]['sailthru_customfield_name'] );
-                                        $name_stripped = stripslashes($name_stripped);
+                                        $name_stripped = stripslashes( $name_stripped );
 					if ( ! empty( $_POST[ 'custom_' . $name_stripped ] ) ) {
 						// check to see if this is an array or a string
 						if ( is_array( $_POST[ 'custom_' . $name_stripped ] ) ) {
@@ -353,7 +353,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 							}
 						} else {
 							$var_name          = str_replace( 'custom_', '', $name_stripped );
-                                                        $vars[$var_name] = stripslashes(sanitize_text_field($_POST['custom_' . $name_stripped]));
+                                                        $vars[ $var_name ] = stripslashes( sanitize_text_field( $_POST [ 'custom_' . $name_stripped ] ) );
 						}
 					}
 				}

--- a/widget.subscribe.php
+++ b/widget.subscribe.php
@@ -353,7 +353,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 							}
 						} else {
 							$var_name          = str_replace( 'custom_', '', $name_stripped );
-                                                        $vars[ $var_name ] = sanitize_text_field( $_POST[ 'custom_' . $name_stripped ] );
+                                                        $vars[ $var_name ] = sanitize_text_field( $_POST[ 'custom_' . $name_stripped ] ); 
 						}
 					}
 				}

--- a/widget.subscribe.php
+++ b/widget.subscribe.php
@@ -342,7 +342,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 
 				if ( ! empty( $customfields[ $field_key ]['sailthru_customfield_name'] ) ) {
 					$name_stripped = preg_replace( '/[^\da-z]/i', '_', $customfields[ $field_key ]['sailthru_customfield_name'] );
-                                $name_stripped = stripslashes($name_stripped);
+                                    $name_stripped = stripslashes($name_stripped);
 					if ( ! empty( $_POST[ 'custom_' . $name_stripped ] ) ) {
 						// check to see if this is an array or a string
 						if ( is_array( $_POST[ 'custom_' . $name_stripped ] ) ) {
@@ -353,7 +353,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 							}
 						} else {
 							$var_name          = str_replace( 'custom_', '', $name_stripped );
-                                        $vars[$var_name] = stripslashes(sanitize_text_field($_POST['custom_' . $name_stripped]));
+                                            $vars[$var_name] = stripslashes(sanitize_text_field($_POST['custom_' . $name_stripped]));
 						}
 					}
 				}

--- a/widget.subscribe.php
+++ b/widget.subscribe.php
@@ -342,7 +342,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 
 				if ( ! empty( $customfields[ $field_key ]['sailthru_customfield_name'] ) ) {
 					$name_stripped = preg_replace( '/[^\da-z]/i', '_', $customfields[ $field_key ]['sailthru_customfield_name'] );
-                                    $name_stripped = stripslashes($name_stripped);
+                                        $name_stripped = stripslashes($name_stripped);
 					if ( ! empty( $_POST[ 'custom_' . $name_stripped ] ) ) {
 						// check to see if this is an array or a string
 						if ( is_array( $_POST[ 'custom_' . $name_stripped ] ) ) {
@@ -353,7 +353,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 							}
 						} else {
 							$var_name          = str_replace( 'custom_', '', $name_stripped );
-                                            $vars[$var_name] = stripslashes(sanitize_text_field($_POST['custom_' . $name_stripped]));
+                                                        $vars[$var_name] = stripslashes(sanitize_text_field($_POST['custom_' . $name_stripped]));
 						}
 					}
 				}

--- a/widget.subscribe.php
+++ b/widget.subscribe.php
@@ -353,7 +353,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 							}
 						} else {
 							$var_name          = str_replace( 'custom_', '', $name_stripped );
-                                                        $vars[ $var_name ] = sanitize_text_field( $_POST [ 'custom_' . $name_stripped ] ) ;
+                                                        $vars[ $var_name ] = sanitize_text_field( $_POST [ 'custom_' . $name_stripped ] );
 						}
 					}
 				}

--- a/widget.subscribe.php
+++ b/widget.subscribe.php
@@ -342,6 +342,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 
 				if ( ! empty( $customfields[ $field_key ]['sailthru_customfield_name'] ) ) {
 					$name_stripped = preg_replace( '/[^\da-z]/i', '_', $customfields[ $field_key ]['sailthru_customfield_name'] );
+					$name_stripped = stripslashes( $name_stripped );
 					if ( ! empty( $_POST[ 'custom_' . $name_stripped ] ) ) {
 						// check to see if this is an array or a string
 						if ( is_array( $_POST[ 'custom_' . $name_stripped ] ) ) {
@@ -352,7 +353,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 							}
 						} else {
 							$var_name          = str_replace( 'custom_', '', $name_stripped );
-                                                        $vars[ $var_name ] = stripslashes( sanitize_text_field( $_POST [ 'custom_' . $name_stripped ] ) );
+                                                        $vars[ $var_name ] = sanitize_text_field( $_POST [ 'custom_' . $name_stripped ] ) ;
 						}
 					}
 				}

--- a/widget.subscribe.php
+++ b/widget.subscribe.php
@@ -342,7 +342,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 
 				if ( ! empty( $customfields[ $field_key ]['sailthru_customfield_name'] ) ) {
 					$name_stripped = preg_replace( '/[^\da-z]/i', '_', $customfields[ $field_key ]['sailthru_customfield_name'] );
-
+                    $name_stripped = stripslashes($name_stripped);
 					if ( ! empty( $_POST[ 'custom_' . $name_stripped ] ) ) {
 						// check to see if this is an array or a string
 						if ( is_array( $_POST[ 'custom_' . $name_stripped ] ) ) {
@@ -353,7 +353,7 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 							}
 						} else {
 							$var_name          = str_replace( 'custom_', '', $name_stripped );
-							$vars[ $var_name ] = sanitize_text_field( $_POST[ 'custom_' . $name_stripped ] );
+                            $vars[$var_name] = stripslashes(sanitize_text_field($_POST['custom_' . $name_stripped]));
 						}
 					}
 				}

--- a/widget.subscribe.php
+++ b/widget.subscribe.php
@@ -342,7 +342,6 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 
 				if ( ! empty( $customfields[ $field_key ]['sailthru_customfield_name'] ) ) {
 					$name_stripped = preg_replace( '/[^\da-z]/i', '_', $customfields[ $field_key ]['sailthru_customfield_name'] );
-                                        $name_stripped = stripslashes( $name_stripped );
 					if ( ! empty( $_POST[ 'custom_' . $name_stripped ] ) ) {
 						// check to see if this is an array or a string
 						if ( is_array( $_POST[ 'custom_' . $name_stripped ] ) ) {


### PR DESCRIPTION
Added stripslashes() before using the sanitised field name should remove the backslashes.