### PR TITLE
Remove custom fields from admin panel dropdown

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: sailthru-wp
 Tags: personalization, email,
 Requires at least: 5.5
 Tested up to: 5.7
-Stable tag: 4.3.7
+Stable tag: 4.3.8
 
 Provides an integration with Sailthru
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 # Changelog
+## v4.3.8 (2024-07-26)
+Custom fields: Radio buttons, checkboxes, hidden fields, and select options not working so removed from dropdown.
+
 ## v4.3.7 (2024-06-06)
 Resolved issue with quotes not encoding properly
 

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name:        Sailthru for WordPress
 Plugin URI:         http://sailthru.com/
 Description:        Add the power of Sailthru to your WordPress set up.
-Version:            4.3.7
+Version:            4.3.8
 Requires at least:  5.5
 Author:             Sailthru
 Author URI:         http://sailthru.com
@@ -36,7 +36,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  * @var   const    $version    The current version of the plugin.
  */
 if ( ! defined( 'SAILTHRU_PLUGIN_VERSION' ) ) {
-	define( 'SAILTHRU_PLUGIN_VERSION', '4.3.7' );
+	define( 'SAILTHRU_PLUGIN_VERSION', '4.3.8' );
 }
 
 if ( ! defined( 'SAILTHRU_PLUGIN_PATH' ) ) {

--- a/views/admin.functions.subscribe.options.php
+++ b/views/admin.functions.subscribe.options.php
@@ -163,10 +163,6 @@ function sailthru_initialize_forms_options() {
 				  <option value="text"' . selected( esc_attr( $value ), 'text' ) . '>Text Field</option>
 				  <option value="tel"' . selected( esc_attr( $value ), 'tel' ) . '>Telephone</option>
 				  <option value="date"' . selected( esc_attr( $value ), 'date' ) . '>Date</option>
-				  <option value="hidden"' . selected( esc_attr( $value ), 'hidden' ) . '>Hidden</option>
-				  <option value="select"' . selected( esc_attr( $value ), 'select' ) . '>Select</option>
-				  <option value="radio"' . selected( esc_attr( $value ), 'radio' ) . '>Radio</option>
-				  <option value="checkbox"' . selected( esc_attr( $value ), 'radio' ) . '>Checkbox</option>
 			  </select>';
 		echo  '<div class="instructions">The type of html form field displayed.</div>';
 


### PR DESCRIPTION
INT-965

**Custom fields:** Radio buttons, checkboxes, hidden fields, and select options are not working, so they have been removed from the dropdown in the admin panel.