### PR TITLE
Fix array access warning in generate_meta_tags method

### DIFF
--- a/classes/class-sailthru-content.php
+++ b/classes/class-sailthru-content.php
@@ -440,10 +440,15 @@ class Sailthru_Content_Settings {
 			$image = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' );
 			$thumb = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'concierge-thumb' );
 
-			$post_image                           = $image[0];
-			$horizon_tags['sailthru.image.full']  = esc_attr( $post_image );
-			$post_thumbnail                       = $thumb[0];
-			$horizon_tags['sailthru.image.thumb'] = $post_thumbnail;
+			if ( $image && isset( $image[0] ) ) {
+				$post_image                           = $image[0];
+				$horizon_tags['sailthru.image.full']  = esc_attr( $post_image );
+			}
+			
+			if ( $thumb && isset( $thumb[0] ) ) {
+				$post_thumbnail                       = $thumb[0];
+				$horizon_tags['sailthru.image.thumb'] = $post_thumbnail;
+			}
 		}
 
 		// expiration date


### PR DESCRIPTION
**Issue:** PHP 8+ throws warnings when trying to access array offset on boolean values. The `wp_get_attachment_image_src()` function can return `false` even when `has_post_thumbnail()` returns `true` (e.g., when image files are missing or corrupted).

**Fix:** Add proper validation to check if the image data is available before accessing array indices. This prevents PHP warnings while maintaining all existing functionality.