### PR TITLE
Fix PHP warning for array offset on bool in generate_meta_tags

### DIFF
--- a/classes/class-sailthru-content.php
+++ b/classes/class-sailthru-content.php
@@ -437,13 +437,16 @@ class Sailthru_Content_Settings {
 
 		// image & thumbnail
 		if ( has_post_thumbnail( $post_object->ID ) ) {
-			$image = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' );
-			$thumb = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'concierge-thumb' );
+			$thumbnail_id = get_post_thumbnail_id( $post_object->ID );
+			$image        = wp_get_attachment_image_src( $thumbnail_id, 'full' );
+			$thumb        = wp_get_attachment_image_src( $thumbnail_id, 'concierge-thumb' );
 
-			$post_image                           = $image[0];
-			$horizon_tags['sailthru.image.full']  = esc_attr( $post_image );
-			$post_thumbnail                       = $thumb[0];
-			$horizon_tags['sailthru.image.thumb'] = $post_thumbnail;
+			if ( is_array( $image ) ) {
+				$horizon_tags['sailthru.image.full'] = $image[0];
+			}
+			if ( is_array( $thumb ) ) {
+				$horizon_tags['sailthru.image.thumb'] = $thumb[0];
+			}
 		}
 
 		// expiration date


### PR DESCRIPTION
## Summary

- Fixes `$post->ID` → `$post_object->ID` in `generate_meta_tags()` to match the rest of the method
- Adds `is_array()` checks before accessing `wp_get_attachment_image_src()` return values, which returns `false` when the attachment is missing

## Test plan

- [ ] Verify no PHP warnings on posts with thumbnails
- [ ] Verify no PHP warnings on posts without thumbnails
- [ ] Verify Sailthru meta tags still render correctly for image.full and image.thumb

Fixes #129