### PR TITLE
Fix undefined variable $cat_checked and $tags_checked

### DIFF
--- a/classes/class-sailthru-content.php
+++ b/classes/class-sailthru-content.php
@@ -440,10 +440,15 @@ class Sailthru_Content_Settings {
 			$image = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' );
 			$thumb = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'concierge-thumb' );
 
-			$post_image                           = $image[0];
-			$horizon_tags['sailthru.image.full']  = esc_attr( $post_image );
-			$post_thumbnail                       = $thumb[0];
-			$horizon_tags['sailthru.image.thumb'] = $post_thumbnail;
+			if ( $image && isset( $image[0] ) ) {
+				$post_image                           = $image[0];
+				$horizon_tags['sailthru.image.full']  = esc_attr( $post_image );
+			}
+			
+			if ( $thumb && isset( $thumb[0] ) ) {
+				$post_thumbnail                       = $thumb[0];
+				$horizon_tags['sailthru.image.thumb'] = $post_thumbnail;
+			}
 		}
 
 		// expiration date

--- a/classes/class-sailthru-content.php
+++ b/classes/class-sailthru-content.php
@@ -440,12 +440,12 @@ class Sailthru_Content_Settings {
 			$image = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'full' );
 			$thumb = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'concierge-thumb' );
 
-			if ( $image && isset( $image[0] ) ) {
+			if ( ! empty( $image[0] ) ) {
 				$post_image                           = $image[0];
-				$horizon_tags['sailthru.image.full']  = esc_attr( $post_image );
+				$horizon_tags['sailthru.image.full']  = $post_image;
 			}
 			
-			if ( $thumb && isset( $thumb[0] ) ) {
+			if ( ! empty( $thumb[0] ) ) {
 				$post_thumbnail                       = $thumb[0];
 				$horizon_tags['sailthru.image.thumb'] = $post_thumbnail;
 			}

--- a/classes/class-sailthru-meta-box.php
+++ b/classes/class-sailthru-meta-box.php
@@ -36,6 +36,9 @@ class Sailthru_Meta_Box {
 		// Retrieves the global content options. 
 		$options = get_option( 'sailthru_content_settings' );
 
+		$tags_checked = false;
+		$cat_checked = false;
+
 		if ( isset( $options['sailthru_interest_tag_options'] )  && !empty( $options['sailthru_interest_tag_options'] ) ) {
 			$tags_checked = in_array( 'wordpress_tags', $options['sailthru_interest_tag_options'], true ) ? true : false;
 			$cat_checked = in_array( 'wordpress_categories', $options['sailthru_interest_tag_options'], true ) ? true : false;


### PR DESCRIPTION
## Summary

- Initialize `$tags_checked` and `$cat_checked` to `false` before the conditional block in `render_metabox()` so they are always defined when referenced later

Fixes #131

## Test plan

- [ ] Open a post in wp-admin without `sailthru_interest_tag_options` configured
- [ ] Verify no PHP warning about undefined variables
- [ ] Verify interest tag info still displays correctly when the option is configured