### PR TITLE
fix: add HMAC signature verification on subscribe list field

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: sailthru-wp
 Tags: personalization, email,
 Requires at least: 5.5
 Tested up to: 5.7
-Stable tag: 4.3.10
+Stable tag: 4.3.11
 
 Provides an integration with Sailthru
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 # Changelog
+## v4.3.11 (2026-05-20)
+Security fix: Added HMAC signature verification on the subscribe widget list field to prevent parameter tampering that allowed attackers to create arbitrary lists
+
 ## v4.3.10 (2026-03-06)
 Minify widget JS and widgetsubscribe JS files and serve .min.js versions to improve page load performance
 

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name:        Sailthru for WordPress
 Plugin URI:         http://sailthru.com/
 Description:        Add the power of Sailthru to your WordPress set up.
-Version:            4.3.10
+Version:            4.3.11
 Requires at least:  5.5
 Author:             Sailthru
 Author URI:         http://sailthru.com
@@ -36,7 +36,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  * @var   const    $version    The current version of the plugin.
  */
 if ( ! defined( 'SAILTHRU_PLUGIN_VERSION' ) ) {
-	define( 'SAILTHRU_PLUGIN_VERSION', '4.3.10' );
+	define( 'SAILTHRU_PLUGIN_VERSION', '4.3.11' );
 }
 
 if ( ! defined( 'SAILTHRU_PLUGIN_PATH' ) ) {

--- a/views/widget.subscribe.display.php
+++ b/views/widget.subscribe.display.php
@@ -360,6 +360,7 @@
 				?>
 				<input type="hidden" name="sailthru_nonce" value="<?php echo esc_attr( $nonce) ; ?>" />
 				<input type="hidden" name="sailthru_email_list" value="<?php echo esc_attr( $sailthru_list ); ?>" />
+				<input type="hidden" name="sailthru_list_sig" value="<?php echo esc_attr( Sailthru_Subscribe_Widget::generate_list_signature( $sailthru_list ) ); ?>" />
 				<input type="hidden" name="action" value="add_subscriber" />
 				<input type="hidden" name="source" value="<?php echo esc_attr( $source ); ?>" />
 				<input type="hidden" name="lo_event_name" value="<?php echo esc_attr( $lo_event_name ); ?>" />

--- a/widget.subscribe.php
+++ b/widget.subscribe.php
@@ -488,10 +488,26 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 		}
 
 		if ( empty($sailthru_email_list) ) {
-			return array('Sailthru Subscribe Widget' => 1); // subscriber is an orphan
+			return array('Sailthru Subscribe Widget' => 1);
+		}
+
+		$submitted_sig = isset($_POST['sailthru_list_sig']) ? sanitize_text_field( $_POST['sailthru_list_sig'] ) : '';
+		$expected_sig = self::generate_list_signature( $sailthru_email_list );
+
+		if ( empty( $expected_sig ) || ! hash_equals( $expected_sig, $submitted_sig ) ) {
+			return array();
 		}
 
 		return $this->create_user_api_list_update( $sailthru_email_list );
+	}
+
+	public static function generate_list_signature( $list_value ): string {
+		$sailthru = get_option( 'sailthru_setup_options' );
+		$secret   = ! empty( $sailthru['sailthru_api_secret'] ) ? $sailthru['sailthru_api_secret'] : '';
+		if ( empty( $secret ) ) {
+			return '';
+		}
+		return hash_hmac( 'sha256', $list_value, $secret );
 	}
 
 	private function create_user_api_list_update( $email_list ): array {
@@ -499,6 +515,10 @@ class Sailthru_Subscribe_Widget extends WP_Widget {
 
 		$subscribe_to_lists = [];
 		foreach (array_values($lists) as $list_name) {
+			$list_name = trim( $list_name );
+			if ( empty( $list_name ) ) {
+				continue;
+			}
 			$subscribe_to_lists[$list_name] = 1;
 		}
 


### PR DESCRIPTION
Prevents parameter tampering on the sailthru_email_list hidden field that allowed attackers to create arbitrary lists via the subscribe widget.