### PR TITLE
Release 4.3.12: bump "Tested up to" to WordPress 7.0 (clears WP.org staleness banner)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: sailthru-wp
 Tags: personalization, email,
 Requires at least: 5.5
 Tested up to: 7.0
-Stable tag: 4.3.11
+Stable tag: 4.3.12
 
 Provides an integration with Sailthru
 

--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,7 @@
 Contributors: sailthru-wp
 Tags: personalization, email,
 Requires at least: 5.5
-Tested up to: 5.7
+Tested up to: 7.0
 Stable tag: 4.3.11
 
 Provides an integration with Sailthru

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 # Changelog
+## v4.3.12 (2026-06-11)
+Compatibility: Bumped "Tested up to" to WordPress 7.0. Metadata only — no functional code change.
+
 ## v4.3.11 (2026-05-20)
 Security fix: Added HMAC signature verification on the subscribe widget list field to prevent parameter tampering that allowed attackers to create arbitrary lists
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 # Changelog
-## v4.3.12 (2026-06-11)
+## v4.3.12 (2026-06-12)
 Compatibility: Bumped "Tested up to" to WordPress 7.0. Metadata only — no functional code change.
 
 ## v4.3.11 (2026-05-20)

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name:        Sailthru for WordPress
 Plugin URI:         http://sailthru.com/
 Description:        Add the power of Sailthru to your WordPress set up.
-Version:            4.3.11
+Version:            4.3.12
 Requires at least:  5.5
 Author:             Sailthru
 Author URI:         http://sailthru.com
@@ -36,7 +36,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  * @var   const    $version    The current version of the plugin.
  */
 if ( ! defined( 'SAILTHRU_PLUGIN_VERSION' ) ) {
-	define( 'SAILTHRU_PLUGIN_VERSION', '4.3.11' );
+	define( 'SAILTHRU_PLUGIN_VERSION', '4.3.12' );
 }
 
 if ( ! defined( 'SAILTHRU_PLUGIN_PATH' ) ) {


### PR DESCRIPTION
## What

Cuts **v4.3.12**, a metadata-only release whose sole purpose is to clear the WordPress.org staleness banner by bumping `Tested up to` from `5.7` to `7.0` (current WordPress).

Changes (no functional/code change):
- `README.txt` — `Tested up to: 5.7` → `7.0`; `Stable tag: 4.3.11` → `4.3.12`
- `plugin.php` — `Version:` and `SAILTHRU_PLUGIN_VERSION` → `4.3.12`
- `changelog.md` — `v4.3.12` entry

## Why

The wordpress.org listing shows: *"This plugin hasn't been tested with the latest 3 major releases of WordPress. It may no longer be maintained or supported..."* — triggered **solely** by the stale `Tested up to` value being >3 majors behind current. It's metadata, not a code/security verdict, but it reads as "unmaintained" to prospects (raised by an onboarding customer as a deployment concern), so clearing it has real optics value.

Versioned per the [WordPress deploy runbook](https://sailthru.atlassian.net/wiki/spaces/CHAN/pages/1102512166/Deployment+Verification+Wordpress) so it's a self-contained, deployable release rather than something that has to wait to ride the next bump.

## ⚠️ Before merging / releasing

1. **Smoke-test against WordPress 7.0.** `Tested up to: 7.0` asserts the plugin was tested against WP 7.0; this PR does not include that testing. Install/activate + run core flows (signup widget, Concierge/Scout config, API connectivity) on WP 7.0 and confirm before merge. Fix-then-bump if anything surfaces.
2. **Confirm the changelog date.** The `v4.3.12` entry is dated `2026-06-11` (prep date) — update to the actual deploy date at release if it slips.
3. **Deploy is a manual SVN push.** Per the runbook, after merge a wordpress.org **committer** on `sailthru-widget` runs `wp-deploy.sh` to push to SVN trunk + tag — that is what actually clears the public banner. Merging here alone does not. Confirm who holds committer access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
