### PR TITLE
fix: upgrade actions/checkout v3 → v4

### DIFF
--- a/.github/workflows/minify.yml
+++ b/.github/workflows/minify.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout@v3` → `@v4` in `minify.yml`
- Node.js 20 actions are deprecated; runners will force Node.js 24 by default from June 16th 2026 and remove Node.js 20 entirely on September 16th 2026

## Test plan
- [ ] Verify the minify workflow passes on this PR

Closes [INF-9661](https://sailthru.atlassian.net/browse/INF-9661)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[INF-9661]: https://sailthru.atlassian.net/browse/INF-9661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ